### PR TITLE
Field 'modified_at' is updated on every save

### DIFF
--- a/resources/models/base.py
+++ b/resources/models/base.py
@@ -56,3 +56,8 @@ class ModifiableModel(models.Model):
 
     class Meta:
         abstract = True
+
+    def save(self, *args, **kwargs):
+        """ Updated modified timestamp on save"""
+        self.modified_at = timezone.now()
+        return super(ModifiableModel, self).save(*args, **kwargs)


### PR DESCRIPTION
Previously modified_at was updated only in creation and it could not
be used to determine if data has actually changed afterwards.

Another solution is add `auto_now` to the field definition. This approach is suggested alternative which avoids behind the scenes magic. See https://stackoverflow.com/questions/1737017/django-auto-now-and-auto-now-add/1737078#.