### PR TITLE
Does not sync events too far in the past or the future

### DIFF
--- a/respa/settings.py
+++ b/respa/settings.py
@@ -87,6 +87,8 @@ env = environ.Env(
     O365_API_URL=(str, 'https://graph.microsoft.com/v1.0'),
     O365_NOTIFICATION_URL=(str, None),
     O365_CALLBACK_URL=(str, None),
+    O365_SYNC_DAYS_BACK=(int, 8),
+    O365_SYNC_DAYS_FORWARD=(int, 92)
 )
 environ.Env.read_env()
 # used for generating links to images, when no request context is available
@@ -382,6 +384,8 @@ O365_TOKEN_URL=env('O365_TOKEN_URL')
 O365_API_URL=env('O365_API_URL')
 O365_NOTIFICATION_URL=env('O365_NOTIFICATION_URL')
 O365_CALLBACK_URL=env('O365_CALLBACK_URL')
+O365_SYNC_DAYS_FORWARD=env('O365_SYNC_DAYS_FORWARD')
+O365_SYNC_DAYS_BACK=env('O365_SYNC_DAYS_BACK')
 
 from easy_thumbnails.conf import Settings as thumbnail_settings  # noqa
 THUMBNAIL_PROCESSORS = (

--- a/respa_o365/calendar_login.py
+++ b/respa_o365/calendar_login.py
@@ -66,10 +66,12 @@ class LoginCallBackView(APIView):
         try:
             stored_data = OutlookTokenRequestData.objects.get(state=state)
         except OutlookTokenRequestData.DoesNotExist:
+            logger.error("Stored data does not exist for state.")
             return Response(data="Invalid state.", status=status.HTTP_400_BAD_REQUEST)
 
         if OutlookCalendarLink.objects.filter(resource=stored_data.resource, user=stored_data.user).exists():
             # Link already exists
+            logger.warn("Already linked user {} resource {}.".format(stored_data.user, stored_data.resource))
             return HttpResponseRedirect(redirect_to=stored_data.return_to)
 
         url = request.build_absolute_uri(request.get_full_path())
@@ -90,6 +92,7 @@ class LoginCallBackView(APIView):
         )
 
         perform_sync_to_exchange(link, lambda sync: sync.sync_all())
+
         ensure_notification(link)
         stored_data.delete()
 

--- a/respa_o365/django_signal_handlers.py
+++ b/respa_o365/django_signal_handlers.py
@@ -15,5 +15,5 @@ def handle_reservation_save(instance, **kwargs):
         return
     links = OutlookCalendarLink.objects.select_for_update().filter(resource=instance.resource)
     for link in links:
-        logger.info("Save of reservation {} launch sync of {}", instance.id, link.id)
+        logger.info("Save of reservation {} launch sync of {}".format(instance.id, link.id))
         perform_sync_to_exchange(link, lambda s: s.sync_all())

--- a/respa_o365/o365_notifications.py
+++ b/respa_o365/o365_notifications.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime, timedelta
+from respa_o365.o365_calendar import MicrosoftApiError
 
 
 class O365Notifications:
@@ -7,7 +8,10 @@ class O365Notifications:
         self._api = microsoft_api
 
     def list(self):
-        result = self._api.get("subscriptions")
+        try: 
+            result = self._api.get("subscriptions")
+        except MicrosoftApiError:
+            return []
         return result.get("value")
 
     def create(self, resource, events, notification_url, client_state):
@@ -27,7 +31,10 @@ class O365Notifications:
         return result.json().get("id")
 
     def get(self, id):
-        result = self._api.get("subscriptions/{}".format(id))
+        try:
+            result = self._api.get("subscriptions/{}".format(id))
+        except MicrosoftApiError:
+            result = None
         return result
 
     def delete(self, id):


### PR DESCRIPTION
Defaults are to leave events 8 days in the past and 92 days in the
future alone.

Configurable using O365_SYNC_DAYS_BACK and O365_SYNC_DAYS_FORWARD

Also:
* Can handle calendar events with empty subject
* Fix sync loop when removing reservation in Outlook