### PR TITLE
Improves handling of removed calendar links

### DIFF
--- a/respa_o365/apps.py
+++ b/respa_o365/apps.py
@@ -31,4 +31,10 @@ class RespaO365Config(AppConfig):
             dispatch_uid='respa-o365-period-delete'
         )
 
+        from respa_o365.django_signal_handlers import handle_calendar_link_delete
+        pre_delete.connect(
+            handle_calendar_link_delete,
+            sender='respa_o365.OutlookCalendarLink'
+        )
+
     

--- a/respa_o365/calendar_sync.py
+++ b/respa_o365/calendar_sync.py
@@ -128,7 +128,8 @@ def ensure_notification(link):
     sub_id, created = subscriptions.ensureNotifications(notification_url=url,
                                                         resource="/me/events",
                                                         events=["updated", "deleted", "created"],
-                                                        client_state=random_secret
+                                                        client_state=random_secret,
+                                                        subscription_id=link.exchange_subscription_id
                                                         )
     if created:
         link.exchange_subscription_id = sub_id

--- a/respa_o365/django_signal_handlers.py
+++ b/respa_o365/django_signal_handlers.py
@@ -1,10 +1,12 @@
 import logging
+from respa_o365.o365_notifications import O365Notifications
+from respa_o365.o365_calendar import MicrosoftApi, O365Calendar
 
 from django.db import transaction
 
 from resources.models import Reservation
 from respa_o365.calendar_sync import perform_sync_to_exchange
-from respa_o365.models import OutlookCalendarReservation, OutlookCalendarLink
+from respa_o365.models import OutlookCalendarAvailability, OutlookCalendarReservation, OutlookCalendarLink
 from respa_o365.sync_operations import ChangeType
 
 logger = logging.getLogger(__name__)
@@ -24,3 +26,17 @@ def handle_period_save(instance, **kwargs):
 
     if OutlookCalendarLink.objects.filter(resource=instance.resource).exists():
         raise Exception("Editing the period directly is not allowed when the resource is connected to an Outlook calendar.")
+
+def handle_calendar_link_delete(instance, **kwargs):
+    # Clear outlook
+    token = instance.token
+    api = MicrosoftApi(token)
+    notifications = O365Notifications(microsoft_api=api)
+    notifications.delete(instance.exchange_subscription_id)
+    cal = O365Calendar(microsoft_api=api)
+    reservation_mappings = OutlookCalendarReservation.objects.filter(calendar_link_id=instance.id)
+    for m in reservation_mappings:
+        cal.remove_event(m.exchange_id)
+    availabiltiy_mappings = OutlookCalendarAvailability.objects.filter(calendar_link_id=instance.id)
+    for m in availabiltiy_mappings:
+        cal.remove_event(m.exchange_id)

--- a/respa_o365/o365_notifications.py
+++ b/respa_o365/o365_notifications.py
@@ -50,13 +50,14 @@ class O365Notifications:
         if result == 201:
             raise SubscriptionError(result)
 
-    def ensureNotifications(self, notification_url, resource, events, client_state):
+    def ensureNotifications(self, notification_url, resource, events, client_state, subscription_id):
         subscriptions = self.list()
         key = None
         for s in subscriptions:
             if s.get("resource") == resource and s.get("notificationUrl"):
-                if not key:
-                    key = s.get("id")
+                id = s.get("id")
+                if not key and id == subscription_id:
+                    key = id
                     self.renew(key)
                 else:
                     self.delete(s.get("id"))

--- a/respa_o365/tests/test_o365_notifications.py
+++ b/respa_o365/tests/test_o365_notifications.py
@@ -27,8 +27,8 @@ url = "https://fgno8xsw1i.execute-api.eu-north-1.amazonaws.com/v1/o365/notificat
 def test__ensure_notification():
     s = O365Notifications(create_api())
     clear_all_subscriptions()
-    id1, created1 = s.ensureNotifications(notification_url=url, resource="me/events", events=["updated", "deleted", "created"], client_state="tila1")
-    id2, created2 = s.ensureNotifications(notification_url=url, resource="me/events", events=["updated", "deleted", "created"], client_state="tila1")
+    id1, created1 = s.ensureNotifications(notification_url=url, resource="me/events", events=["updated", "deleted", "created"], client_state="tila1", subscription_id=None)
+    id2, created2 = s.ensureNotifications(notification_url=url, resource="me/events", events=["updated", "deleted", "created"], client_state="tila1", subscription_id=None)
     assert id1 == id2
     assert created1
     assert not created2

--- a/respa_o365/views.py
+++ b/respa_o365/views.py
@@ -29,16 +29,3 @@ class OutlookCalendarLinkViewSet(viewsets.ModelViewSet):
 
             return queryset
         return OutlookCalendarLink.objects.none()
-
-    def perform_destroy(self, instance):
-        # Clear outlook
-        token = instance.token
-        api = MicrosoftApi(token)
-        notifications = O365Notifications(microsoft_api=api)
-        notifications.delete(instance.exchange_subscription_id)
-        cal = O365Calendar(microsoft_api=api)
-        mappings = OutlookCalendarReservation.objects.filter(calendar_link_id=instance.id)
-        for m in mappings:
-            cal.remove_event(m.exchange_id)
-        mappings.delete()
-        super().perform_destroy(instance)


### PR DESCRIPTION
These fixes make sure events and change notification subscriptions get removed when removing a calendar link. Also if there is still any active subscription that belongs to a removed calendar link, that gets handled better.