### PR TITLE
order details to notification context

### DIFF
--- a/payments/tests/conftest.py
+++ b/payments/tests/conftest.py
@@ -37,6 +37,48 @@ def two_hour_reservation(resource_in_unit, user):
         billing_address_city='Testcity',
     )
 
+@pytest.fixture()
+def three_hour_thirty_minute_reservation(resource_in_unit, user):
+    """A three and a half hour reservation fixture with actual datetime objects"""
+    return Reservation.objects.create(
+        resource=resource_in_unit,
+        begin=datetime.datetime(2048, 1, 20, 12, 0, 0, tzinfo=UTC),
+        end=datetime.datetime(2048, 1, 20, 15, 30, 0, tzinfo=UTC),
+        user=user,
+        event_subject='a three and a half hour event',
+        host_name='Esko Esimerkki',
+        reserver_name='Martta Meikäläinen',
+        state=Reservation.CONFIRMED,
+        billing_first_name='Mikko',
+        billing_last_name='Maksaja',
+        billing_email_address='mikko@maksaja.com',
+        billing_phone_number='555555555',
+        billing_address_street='Maksupolku 1',
+        billing_address_zip='12345',
+        billing_address_city='Kaupunkikylä',
+    )
+
+@pytest.fixture()
+def order_with_product(three_hour_thirty_minute_reservation):
+    Reservation.objects.filter(id=three_hour_thirty_minute_reservation.id).update(state=Reservation.WAITING_FOR_PAYMENT)
+    three_hour_thirty_minute_reservation.refresh_from_db()
+
+    order = OrderFactory.create(
+        order_number='123orderABC',
+        state=Order.WAITING,
+        reservation=three_hour_thirty_minute_reservation
+    )
+    OrderLineFactory.create(
+        quantity=1,
+        product__name="Test product",
+        product__price=Decimal('18.00'),
+        product__tax_percentage=Decimal('24.00'),
+        product__price_type=Product.PRICE_PER_PERIOD,
+        product__price_period=datetime.timedelta(hours=0.5),
+        order=order
+    )
+
+    return order
 
 @pytest.fixture()
 def order_with_products(two_hour_reservation):

--- a/payments/tests/test_notifications.py
+++ b/payments/tests/test_notifications.py
@@ -23,6 +23,7 @@ def get_body_with_all_template_vars():
         'order_line.price',
         'order_line.quantity',
         'order_line.unit_price',
+        'order_details',
         'product.id',
         'product.name',
         'product.description',
@@ -42,6 +43,7 @@ def get_body_with_all_template_vars():
 def get_expected_strings(order):
     order_line = order.order_lines.first()
     product = order_line.product
+    order_details ='[' + ', '.join([str(x) for x in order.reservation.get_notification_context('fi')['order_details']]) + ']'
     return (
         order.order_number,
         str(order.created_at.year),
@@ -49,6 +51,7 @@ def get_expected_strings(order):
         localize_decimal(order_line.get_price()),
         str(order_line.quantity),
         localize_decimal(order_line.get_unit_price()),
+        order_details,
         product.product_id,
         product.name,
         product.description,
@@ -101,6 +104,22 @@ def test_reservation_created_notification(order_with_products):
         'Reservation created subject.',
         order_with_products.reservation.billing_email_address,
         get_expected_strings(order_with_products),
+    )
+
+@pytest.mark.django_db
+@override_settings(RESPA_MAILS_ENABLED=True)
+def test_reservation_created_notification_single_product(order_with_product):
+    user = order_with_product.reservation.user
+    user.preferred_language = 'fi'
+    user.save()
+
+    order_with_product.set_state(Order.CONFIRMED)
+
+    assert len(mail.outbox) == 1
+    check_received_mail_exists(
+        'Reservation created subject.',
+        order_with_product.reservation.billing_email_address,
+        get_expected_strings(order_with_product),
     )
 
 

--- a/payments/tests/test_notifications.py
+++ b/payments/tests/test_notifications.py
@@ -43,7 +43,9 @@ def get_body_with_all_template_vars():
 def get_expected_strings(order):
     order_line = order.order_lines.first()
     product = order_line.product
-    order_details ='[' + ', '.join([str(x) for x in order.reservation.get_notification_context('fi')['order_details']]) + ']'
+    order_details = "[%(details)s]" % ({
+        'details': ', '.join([str(x) for x in order.reservation.get_notification_context('fi')['order_details']])
+    })
     return (
         order.order_number,
         str(order.created_at.year),


### PR DESCRIPTION
## Order details to notification context
### Added a new key to the context object that is used to fill the notification templates
The order data was previously _kind of_ accessible/usable in the templates but these changes add the order's order_lines content into an array under context['order_details'] that is easier to access/use. The data is also manipulated/adjusted so that we don't have to do any big calculations inside of the actual html templates.