### PR TITLE
Changed include rent requirement for unit staff

### DIFF
--- a/payments/api/reservation.py
+++ b/payments/api/reservation.py
@@ -27,7 +27,7 @@ class ReservationEndpointOrderSerializer(OrderSerializerBase):
         customer_group = validated_data.pop('customer_group', None)
         return_url = validated_data.pop('return_url', '')
         order = super().create(validated_data)
-    
+
         for order_line_data in order_lines_data:
             product = order_line_data['product']
             order_line = OrderLine.objects.create(order=order, **order_line_data)
@@ -71,7 +71,8 @@ class ReservationEndpointOrderSerializer(OrderSerializerBase):
             raise serializers.ValidationError(_('Order lines cannot contain duplicate products.'))
 
         resource = self.context.get('resource')
-        if resource and resource.has_rent():
+        request = self.context.get('request')
+        if resource and resource.has_rent() and not resource.can_bypass_payment(request.user):
             if not any(ol['product'].type == Product.RENT for ol in order_lines):
                 raise serializers.ValidationError(_('The order must contain at least one product of type "rent".'))
 

--- a/payments/tests/test_reservation_api.py
+++ b/payments/tests/test_reservation_api.py
@@ -53,7 +53,7 @@ def build_order_data(product, quantity=None, product_2=None, quantity_2=None, cu
         if quantity_2:
             order_line_data['quantity'] = quantity_2
         data['order_lines'].append(order_line_data)
-    
+
     if customer_group:
         data['customer_group'] = customer_group
 
@@ -330,6 +330,17 @@ def test_order_must_include_rent_if_one_exists(user_api_client, resource_in_unit
 
     response = user_api_client.post(LIST_URL, reservation_data)
     assert response.status_code == 400
+
+
+def test_unit_admin_can_bypass_include_rent_requirement(user_api_client, resource_in_unit, user):
+    reservation_data = build_reservation_data(resource_in_unit)
+    ProductFactory(type=Product.RENT, resources=[resource_in_unit])
+    extra = ProductFactory(type=Product.EXTRA, resources=[resource_in_unit])
+    reservation_data['order'] = build_order_data(product=extra)
+    UnitAuthorization.objects.create(subject=resource_in_unit.unit, level=UnitAuthorizationLevel.manager, authorized=user)
+
+    response = user_api_client.post(LIST_URL, reservation_data)
+    assert response.status_code == 201
 
 
 def test_unit_admin_and_unit_manager_may_bypass_payment(user_api_client, resource_in_unit, user):


### PR DESCRIPTION
Unit staff members don't have to include products of type rent in orders when resource has type rent products.