### PR TITLE
Enforce customer group id

### DIFF
--- a/payments/api/reservation.py
+++ b/payments/api/reservation.py
@@ -83,6 +83,14 @@ class ReservationEndpointOrderSerializer(OrderSerializerBase):
             raise serializers.ValidationError({'customer_group': _('Invalid customer group id')}, code='invalid_customer_group')
         return customer_group
 
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        customer_group = attrs.get('customer_group', None)
+        resource = self.context.get('resource')
+        for product in resource.get_products():
+            if product.has_customer_group() and not customer_group:
+                raise serializers.ValidationError(_('Order must have customer group id in it.'))
+        return attrs
 
     def to_internal_value(self, data):
         resource = self.context.get('resource')

--- a/payments/models.py
+++ b/payments/models.py
@@ -257,6 +257,9 @@ class Product(models.Model):
     def get_tax_price(self) -> Decimal:
         return self.price - self.get_pretax_price()
 
+    def has_customer_group(self):
+        return ProductCustomerGroup.objects.filter(product=self).exists()
+
 class OrderQuerySet(models.QuerySet):
     def can_view(self, user):
         if not user.is_authenticated:

--- a/payments/tests/test_reservation_api.py
+++ b/payments/tests/test_reservation_api.py
@@ -230,9 +230,14 @@ def test_order_with_product_cg_post(user_api_client, resource_in_unit, product_w
     ocgd = OrderCustomerGroupData.objects.filter(order_line__in=new_order.get_order_lines(), order_line__product=product_with_product_cg)
     assert ocgd.exists()
 
-def test_order_with_invalid_product_cg_post(user_api_client, resource_in_unit, product_with_product_cg):
+
+@pytest.mark.parametrize('with_customer_group_id', (True, False))
+def test_order_with_invalid_product_cg_post(user_api_client, resource_in_unit, product_with_product_cg, with_customer_group_id):
     reservation_data = build_reservation_data(resource_in_unit)
-    reservation_data['order'] = build_order_data(product=product_with_product_cg, quantity=2, customer_group=generate_id())
+    if with_customer_group_id:
+        reservation_data['order'] = build_order_data(product=product_with_product_cg, quantity=2, customer_group=generate_id())
+    else:
+        reservation_data['order'] = build_order_data(product=product_with_product_cg, quantity=2)
     response = user_api_client.post(LIST_URL, reservation_data)
 
     assert response.status_code == 400, response.data

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -866,6 +866,10 @@ class Resource(ModifiableModel, AutoIdentifiedModel, ValidatedIdentifier):
         if self.id:
             self.validate_id()
 
+    def get_products(self):
+        from payments.models import Product
+        return Product.objects.filter(resources=self)
+
 class ResourceImage(ModifiableModel):
     TYPES = (
         ('main', _('Main photo')),


### PR DESCRIPTION
Orders must have customer group id in request if resource has a product that has a customer group.