### PR TITLE
Fixed wrong confirmed notification being sent

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -380,7 +380,10 @@ class Order(models.Model):
     def get_price(self) -> Decimal:
         return sum(order_line.get_price() for order_line in self.get_order_lines())
 
-    def set_state(self, new_state: str, log_message: str = None, save: bool = True) -> None:
+    def set_state(
+            self, new_state: str, log_message: str = None,
+            save: bool = True, update_reservation_state: bool = True
+        ) -> None:
         assert new_state in (Order.WAITING, Order.CONFIRMED, Order.REJECTED, Order.EXPIRED, Order.CANCELLED)
 
         old_state = self.state
@@ -403,10 +406,11 @@ class Order(models.Model):
 
         self.state = new_state
 
-        if new_state == Order.CONFIRMED:
-            self.reservation.set_state(Reservation.CONFIRMED, None)
-        elif new_state in (Order.REJECTED, Order.EXPIRED, Order.CANCELLED):
-            self.reservation.set_state(Reservation.CANCELLED, None)
+        if update_reservation_state:
+            if new_state == Order.CONFIRMED:
+                self.reservation.set_state(Reservation.CONFIRMED, None)
+            elif new_state in (Order.REJECTED, Order.EXPIRED, Order.CANCELLED):
+                self.reservation.set_state(Reservation.CANCELLED, None)
 
         if save:
             self.save()

--- a/payments/providers/turku_payment_provider.py
+++ b/payments/providers/turku_payment_provider.py
@@ -53,7 +53,8 @@ class TurkuPaymentProvider(PaymentProvider):
 
 
         if is_free(order.get_price()):
-            order.set_state(Order.CONFIRMED, 'Order has no price, selected with customer group.')
+            # don't update reservation state here, it is handled later
+            order.set_state(Order.CONFIRMED, 'Order has no price, selected with customer group.', True, False)
             if order.reservation.resource.timmi_resource:
                 logger.debug('Confirming reservation with Timmi API.')
                 TimmiManager().confirm_reservation(order.reservation, timmi_payload.payload).save()


### PR DESCRIPTION
When free requested order is made, setting order state to confirmed should not trigger reservation confirmed notification. Only reservation requested notification is sent in this case.