### PR TITLE
RA Unit authorization levels

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1389,7 +1389,7 @@ msgid "Staff"
 msgstr "Henkilökunta"
 
 msgid "Admin"
-msgstr "Admin"
+msgstr "Ylläpitäjä"
 
 msgid "Viewer"
 msgstr "Katsoja"

--- a/resources/enums.py
+++ b/resources/enums.py
@@ -1,6 +1,11 @@
 from django.utils.translation import ugettext_lazy as _
 from enumfields import Enum
 
+UNIT_AUTH_MAP = {
+    'viewer': 1,
+    'manager': 2,
+    'admin': 3,
+}
 
 class UnitGroupAuthorizationLevel(Enum):
     admin = 'admin'
@@ -19,3 +24,22 @@ class UnitAuthorizationLevel(Enum):
         manager = _("unit manager")
         viewer = _("unit viewer")
 
+
+
+    def __gt__(self, other):
+        return UNIT_AUTH_MAP.get(self._value_, None) > UNIT_AUTH_MAP.get(other._value_, None)
+
+    def __lt__(self, other):
+        return UNIT_AUTH_MAP.get(self._value_, None) < UNIT_AUTH_MAP.get(other._value_, None)
+
+    def __ge__(self, other):
+        return UNIT_AUTH_MAP.get(self._value_, None) >= UNIT_AUTH_MAP.get(other._value_, None)
+
+    def __le__(self, other):
+        return UNIT_AUTH_MAP.get(self._value_, None) <= UNIT_AUTH_MAP.get(other._value_, None)
+        
+    def below(self):
+        return [label for label, level in UNIT_AUTH_MAP.items() if level < UNIT_AUTH_MAP[self._value_]]
+    
+    def above(self):
+        return [label for label, level in UNIT_AUTH_MAP.items() if level > UNIT_AUTH_MAP[self._value_]]

--- a/resources/models/unit.py
+++ b/resources/models/unit.py
@@ -245,6 +245,35 @@ class UnitAuthorization(models.Model):
             unit=self.subject, level=self.level, user=self.authorized)
 
 
+    def __gt__(self, other):
+        return self.level > other.level
+
+    def __lt__(self, other):
+        return self.level < other.level
+
+    def __ge__(self, other):
+        return self.level >= other.level
+
+    def __le__(self, other):
+        return self.level <= other.level
+
+    
+    def _ensure_lower_auth(self):
+        """
+        Ensure that the user also has permission levels lower than the given one.
+        """
+
+        auths = UnitAuthorization.objects.filter(subject=self.subject, authorized=self.authorized, level__lt=self.level)
+        if not auths:
+            for level in self.level.below():
+                UnitAuthorization.objects.get_or_create(authorized=self.authorized, subject=self.subject, level=level)
+        else:
+            highest = max(auths)
+            for level in highest.level.below():
+                UnitAuthorization.objects.get_or_create(authorized=self.authorized, subject=self.subject, level=level)
+            
+
+
 class UnitIdentifier(models.Model):
     unit = models.ForeignKey('Unit', verbose_name=_('Unit'), db_index=True, related_name='identifiers',
                              on_delete=models.CASCADE)

--- a/resources/models/unit.py
+++ b/resources/models/unit.py
@@ -219,7 +219,12 @@ class UnitAuthorizationQuerySet(models.QuerySet):
             UnitAuthorizationLevel.admin,
             UnitAuthorizationLevel.manager,
         })
-
+    
+    def highest_per_user(self):
+        return self.filter(id__in=[
+            max(self.filter(authorized=user)).id 
+            for user in self.values_list('authorized', flat=True).distinct()
+        ])
 
 class UnitAuthorization(models.Model):
     subject = models.ForeignKey(

--- a/respa_admin/forms.py
+++ b/respa_admin/forms.py
@@ -578,7 +578,7 @@ class UnitAuthorizationForm(forms.ModelForm):
             user_has_unit_group_auth = self.request.user.unit_group_authorizations.to_unit(unit).admin_level().exists()
             can_approve_initial_value = permission_checker.has_perm(
                 "unit:can_approve_reservation", self.instance.subject
-            )
+            ) or self.instance.subject.is_manager(self.instance.authorized)
             if not user_has_unit_auth and not user_has_unit_group_auth:
                 self.fields['subject'].disabled = True
                 self.fields['level'].disabled = True

--- a/respa_admin/templates/respa_admin/resources/_unit_user_list.html
+++ b/respa_admin/templates/respa_admin/resources/_unit_user_list.html
@@ -33,7 +33,7 @@
             {% for unit in units %}
             <span class="sub-header">{{ unit.name }}</span>
 
-                {% for authorization in unit.authorizations.all %}
+                {% for authorization in sorted_authorization_list %}
                 {% with authorization.authorized as unit_user %}
                 {% user_has_permission unit_user 'can_approve_reservation' unit as user_can_approve %}
 
@@ -55,13 +55,13 @@
                                 <span>{% trans 'Admin' %}</span>
                             </div>
                             <div>
-                                <span class="{% if authorization.level == authorization.level.viewer %}shape-success{% else %}shape-danger{% endif %}"></span>
+                                <span class="{% if authorization.level >= authorization.level.viewer %}shape-success{% else %}shape-danger{% endif %}"></span>
                                 <span>{% trans 'Viewer' %}</span>
                             </div>
                         </div>
                         <div class="col-md-8">
                             <div>
-                                <span class="{% if authorization.level == authorization.level.manager %}shape-success{% else %}shape-danger{% endif %}"></span>
+                                <span class="{% if authorization.level >= authorization.level.manager %}shape-success{% else %}shape-danger{% endif %}"></span>
                                 <span>{% trans 'Manager' %}</span>
                             </div>
                             <div>

--- a/respa_admin/templates/respa_admin/resources/_unit_user_list.html
+++ b/respa_admin/templates/respa_admin/resources/_unit_user_list.html
@@ -33,7 +33,7 @@
             {% for unit in units %}
             <span class="sub-header">{{ unit.name }}</span>
 
-                {% for authorization in sorted_authorization_list %}
+                {% for authorization in unit.authorizations.highest_per_user %}
                 {% with authorization.authorized as unit_user %}
                 {% user_has_permission unit_user 'can_approve_reservation' unit as user_can_approve %}
 

--- a/respa_admin/templatetags/templatetags.py
+++ b/respa_admin/templatetags/templatetags.py
@@ -40,7 +40,7 @@ def get_value_from_dict(dict_data, key):
 
 @register.simple_tag
 def user_has_permission(user, permission, obj):
-    return user.has_perm(permission, obj)
+    return user.has_perm(permission, obj) or obj.is_manager(user)
 
 
 @register.filter

--- a/respa_admin/views/resources.py
+++ b/respa_admin/views/resources.py
@@ -229,8 +229,6 @@ class ManageUserPermissionsListView(ExtraContextMixin, ListView):
         context['selected_unit'] = self.selected_unit or ''
         context['all_available_units'] = self.get_all_available_units()
         context['user_list_template_name'] = self.user_list_template_name
-        unit_auth_users = UnitAuthorization.objects.all().values_list('authorized', flat=True).distinct()
-        context['sorted_authorization_list'] = [max(UnitAuthorization.objects.filter(authorized=user)) for user in unit_auth_users]
         return context
 
 


### PR DESCRIPTION
**Keep everything organized by automatically ensuring that the user also gets the permissions below the given one.**
- Ensure Admin gets manager and viewer permissions
- Ensure Manager also gets viewer permission
- Ensure Viewer only gets viewer permission

**Other fixes**:
- Properly show who can approve reservations