### PR TITLE
O365: Management commands don't use the same lockfile

### DIFF
--- a/respa_o365/management/commands/o365_process_sync_queue.py
+++ b/respa_o365/management/commands/o365_process_sync_queue.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
     def handle(self, *args: Any, **options: Any) -> Optional[str]:
         logger.info("Processing sync queue.")
         try:
-            me = singleton.SingleInstance()
+            me = singleton.SingleInstance(flavor_id="o365_process_sync_queue")
         except singleton.SingleInstanceException:
             return
         process_queue()

--- a/respa_o365/management/commands/o365_queue_all_resources_for_sync.py
+++ b/respa_o365/management/commands/o365_queue_all_resources_for_sync.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
 
     def handle(self, *args: Any, **options: Any) -> Optional[str]:
         try:
-            me = singleton.SingleInstance()
+            me = singleton.SingleInstance(flavor_id="o365_queue_all_resources_for_sync")
         except singleton.SingleInstanceException:
             return
 


### PR DESCRIPTION
# O365: Management commands don't use the same lockfile

## The two management commands for O365 calendar sync used to use the same lockfile

### Respa O365 calendar sync bugfix

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Kategoria-otsikko
 1. o365_process_sync_queue.py 
     * Initializes SingleInstance object with flavor_id argument so it appends a unique string to the lockfile filename
   
 2. o365_queue_all_resources_for_sync.py
     * Initializes SingleInstance object with flavor_id argument so it appends a unique string to the lockfile filename


