### PR TITLE
Increase the limit for images, periods and tags

### DIFF
--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -1559,17 +1559,17 @@ class ResourceCreateSerializer(TranslatedModelSerializer):
         extra = (
             ('images', 
                 {'kwargs': { 'many': True, 'context': self.context, 'data': validated_data.pop('images', {}), },
-                    'validate': ( (lambda data: len(data) <= 5, _('Invalid length, max: 5')), ),
+                    'validate': ( (lambda data: len(data) <= 20, _('Invalid length, max: 20')), ),
                     'save_kw': { 'resource_fk': True, }, } ),
 
             ('tags',
                 {'kwargs': {'many': True, 'context': self.context, 'data': validated_data.pop('tags', []), },
-                    'validate': ( (lambda data: len(data) <= 20,  _('Invalid length, max: 20')), ),
+                    'validate': ( (lambda data: len(data) <= 100,  _('Invalid length, max: 100')), ),
                     'save_kw': { 'resource_fk': True }, } ),
 
             ('periods', 
                 { 'kwargs': { 'many': True, 'context': self.context, 'data': validated_data.pop('periods', {}), },
-                    'validate': ( (lambda data: len(data) <= 10,  _('Invalid length, max: 10')), ),
+                    'validate': ( (lambda data: len(data) <= 20,  _('Invalid length, max: 20')), ),
                     'save_kw': { 'resource_fk': True }, } ),
     
             ('equipments', 


### PR DESCRIPTION
# Increase the limit for images, periods and tags

### Currently api only allows 5 images, 20 tags and 10 periods to be created at once, increased the amount to 20 images, 100 tags and 20 periods

-----------------------------------------------------------------------------------------------
### Breakdown:

#### API
 1. resources/api/resource.py 
     * Increased limit before validation fails
