### PR TITLE
Add 0 hour cooldown option

### DIFF
--- a/respa_admin/forms.py
+++ b/respa_admin/forms.py
@@ -325,7 +325,9 @@ class ResourceForm(forms.ModelForm):
                 choices=(thirty_minute_increment_choices)
             ),
             'cooldown': forms.Select(
-                choices=(thirty_minute_increment_choices)
+                choices=(
+                    (('00:00:00', '0 h') , ) + thirty_minute_increment_choices
+                )
             ),
             'need_manual_confirmation': RespaRadioSelect(
                 choices=((True, _('Yes')), (False, _('No')))


### PR DESCRIPTION
# Add 0 hour cooldown option

## Add missing 0 hour cooldown field option

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Resource Form
 1. respa_admin/forms.py 
     * Add 0h option
   
