### PR TITLE
Docker: Persist media folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile
+    volumes:
+      - ./media:/var/www/media
     ports:
       - 8000:8000
     depends_on:
@@ -16,7 +18,6 @@ services:
       dockerfile: ./docker/postgres/Dockerfile
     volumes:
       - db_respa_data:/var/lib/postgresql/data
-      - respa_media:/var/www/media
     ports:
       - "5432:5432"
     env_file:
@@ -24,4 +25,3 @@ services:
 
 volumes:
   db_respa_data:
-  respa_media:


### PR DESCRIPTION
# Docker: Persist media folder

### Media files shouldn't disappear when container is recreated

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Docker compose
 1. docker-compose.yml 
     * Remove respa_media volume, use ./media instead.
