### PR TITLE
cash reservations no longer send final notification

### DIFF
--- a/notifications/tests/utils.py
+++ b/notifications/tests/utils.py
@@ -1,5 +1,5 @@
 from django.core import mail
-
+from payments.utils import get_price_period_display
 
 def _mail_exists(subject, to, strings, html_body):
     for mail_instance in mail.outbox:
@@ -16,6 +16,8 @@ def _mail_exists(subject, to, strings, html_body):
             return True
     return False
 
+def check_mail_was_not_sent():
+    assert len(mail.outbox) == 0, "Mails were sent."
 
 def check_received_mail_exists(subject, to, strings, clear_outbox=True, html_body=None):
     if not (isinstance(strings, list) or isinstance(strings, tuple)):
@@ -24,3 +26,55 @@ def check_received_mail_exists(subject, to, strings, clear_outbox=True, html_bod
     assert _mail_exists(subject, to, strings, html_body)
     if clear_outbox:
         mail.outbox = []
+
+def localize_decimal(d):
+    return str(d).replace('.', ',')
+
+def get_expected_strings(order):
+    order_line = order.order_lines.first()
+    product = order_line.product
+    order_details = "[%(details)s]" % ({
+        'details': ', '.join([str(x) for x in order.reservation.get_notification_context('fi')['order_details']])
+    })
+    return (
+        order.order_number,
+        str(order.created_at.year),
+        localize_decimal(order.get_price()),
+        localize_decimal(order_line.get_price()),
+        str(order_line.quantity),
+        localize_decimal(order_line.get_unit_price()),
+        order_details,
+        product.product_id,
+        product.name,
+        product.description,
+        product.type,
+        product.get_type_display(),
+        product.price_type,
+        product.get_price_type_display(),
+        str(product.price_period),
+        str(get_price_period_display(product.price_period)),
+    )
+
+def get_body_with_all_template_vars():
+    template_vars = (
+        'order.id',
+        'order.created_at',
+        'order.price',
+        'order_line.price',
+        'order_line.quantity',
+        'order_line.unit_price',
+        'order_details',
+        'product.id',
+        'product.name',
+        'product.description',
+        'product.type',
+        'product.type_display',
+        'product.price_type',
+        'product.price_type_display',
+        'product.price_period',
+        'product.price_period_display',
+    )
+    body = '{% set order_line=order.order_lines[0] %}{% set product=order_line.product %}\n'
+    for template_var in template_vars:
+        body += '{{ %s }}\n' % template_var
+    return body

--- a/payments/tests/test_notifications.py
+++ b/payments/tests/test_notifications.py
@@ -4,67 +4,10 @@ from django.test import override_settings
 from django.utils import translation
 
 from notifications.models import NotificationTemplate, NotificationType
-from notifications.tests.utils import check_received_mail_exists
-from payments.utils import get_price_period_display
+from notifications.tests.utils import check_received_mail_exists, get_body_with_all_template_vars, get_expected_strings
 from resources.models import Reservation
 
 from ..models import Order
-
-
-def localize_decimal(d):
-    return str(d).replace('.', ',')
-
-
-def get_body_with_all_template_vars():
-    template_vars = (
-        'order.id',
-        'order.created_at',
-        'order.price',
-        'order_line.price',
-        'order_line.quantity',
-        'order_line.unit_price',
-        'order_details',
-        'product.id',
-        'product.name',
-        'product.description',
-        'product.type',
-        'product.type_display',
-        'product.price_type',
-        'product.price_type_display',
-        'product.price_period',
-        'product.price_period_display',
-    )
-    body = '{% set order_line=order.order_lines[0] %}{% set product=order_line.product %}\n'
-    for template_var in template_vars:
-        body += '{{ %s }}\n' % template_var
-    return body
-
-
-def get_expected_strings(order):
-    order_line = order.order_lines.first()
-    product = order_line.product
-    order_details = "[%(details)s]" % ({
-        'details': ', '.join([str(x) for x in order.reservation.get_notification_context('fi')['order_details']])
-    })
-    return (
-        order.order_number,
-        str(order.created_at.year),
-        localize_decimal(order.get_price()),
-        localize_decimal(order_line.get_price()),
-        str(order_line.quantity),
-        localize_decimal(order_line.get_unit_price()),
-        order_details,
-        product.product_id,
-        product.name,
-        product.description,
-        product.type,
-        product.get_type_display(),
-        product.price_type,
-        product.get_price_type_display(),
-        str(product.price_period),
-        str(get_price_period_display(product.price_period)),
-    )
-
 
 @pytest.fixture(autouse=True)
 def reservation_created_notification():


### PR DESCRIPTION
# cash reservations no longer send mail after state changes from waiting to confirmed


#### Previously cash reservations would send a final notification mail after a staff member checked the reservation as paid. This final notification was identical to the notification that is sent after a staff member approves the reservation so it wasn't really necessary. 

-----------------------------------------------------------------------------------------------
Changes:
- **notifications/tests/utils.py**
Moved a bunch of functions from `payments/tests/test_notifications.py` to this file as they are now used in other test files in addition to their original tests.
- **payments/tests/test_notifications.py**
Moved a bunch of functions to `notifications/tests/utils.py` as they are now also used in other tests.
- **payments/tests/test_reservation_api.py**
The test for cash reservation flow now also tests that the correct notifications are sent at each stage of the process.
- **resources/models/reservation.py**
Reservation `set_state` function now passes the old state value of the reservation to the `handle_notification` function. Modified `handle_notification` so that a notification is **NOT** sent if a reservations state changed from `WAITING_FOR_CASH_PAYMENT` to `CONFIRMED`.

