### PR TITLE
ra/reports page weekday selector

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Overlapping time slot prices"
 msgstr ""
 
-msgid "Resource utilization for period %(start)s - %(end)s"
+msgid "Resource utilization for period %(start)s - %(end)s %(extra)s"
 msgstr ""
 
 msgid "Resource utilization"
@@ -2670,4 +2670,7 @@ msgid "Quality tool target updated"
 msgstr ""
 
 msgid "No target options found"
+msgstr ""
+
+msgid "Selected days: %(selected)s"
 msgstr ""

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2674,3 +2674,6 @@ msgstr ""
 
 msgid "Selected days: %(selected)s"
 msgstr ""
+
+msgid "Weekdays"
+msgstr ""

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2051,3 +2051,6 @@ msgstr "Kohde valintoja ei löytynyt"
 
 msgid "Selected days: %(selected)s"
 msgstr "Valitut päivät: %(selected)s"
+
+msgid "Weekdays"
+msgstr "Viikonpäivät"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1922,8 +1922,8 @@ msgstr "Alkuajan tulee olla ennen loppuaikaa"
 msgid "Overlapping time slot prices"
 msgstr "Päällekkäisiä aikavälihintoja"
 
-msgid "Resource utilization for period %(start)s - %(end)s"
-msgstr "Resurssin käyttöasteet ajalta %(start)s - %(end)s"
+msgid "Resource utilization for period %(start)s - %(end)s %(extra)s"
+msgstr "Resurssin käyttöasteet ajalta %(start)s - %(end)s %(extra)s"
 
 msgid "Resource utilization"
 msgstr "Resurssin käyttöaste"
@@ -2048,3 +2048,6 @@ msgstr "Laatutyökalukohde päivitetty"
 
 msgid "No target options found"
 msgstr "Kohde valintoja ei löytynyt"
+
+msgid "Selected days: %(selected)s"
+msgstr "Valitut päivät: %(selected)s"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -1857,8 +1857,8 @@ msgstr "Början måste vara före slutet"
 msgid "Overlapping time slot prices"
 msgstr "Överlappande tidsluckornas priser"
 
-msgid "Resource utilization for period %(start)s - %(end)s"
-msgstr "Resursens beläggningsgrad för tidsperioden %(start)s - %(end)s"
+msgid "Resource utilization for period %(start)s - %(end)s %(extra)s"
+msgstr "Resursens beläggningsgrad för tidsperioden %(start)s - %(end)s %(extra)s"
 
 msgid "Resource utilization"
 msgstr "Resursens beläggningsgrad"
@@ -1983,3 +1983,6 @@ msgstr "Kvalitetsverktyg mål uppdaterad"
 
 msgid "No target options found"
 msgstr "Inga mål hittades"
+
+msgid "Selected days: %(selected)s"
+msgstr "Utvalda dagar: %(selected)s"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -1986,3 +1986,6 @@ msgstr "Inga mål hittades"
 
 msgid "Selected days: %(selected)s"
 msgstr "Utvalda dagar: %(selected)s"
+
+msgid "Weekdays"
+msgstr "Veckodagar"

--- a/respa_admin/static_src/js/reportForm.js
+++ b/respa_admin/static_src/js/reportForm.js
@@ -217,7 +217,7 @@ function bindGenerateButton() {
 let btnState = false;
 function bindSelectDayPickButton() {
     let weekdayCalendar = $("ul[id=weekday-cal-popup]").parent();
-    let weekdayPopupBtn = $("a[id=weekday-cal-btn]");
+    let weekdayPopupBtn = $("button[id=weekday-cal-btn]");
     let weekdayPopupCloseBtn = $("i[id=popup-close-btn]")
     $(weekdayPopupBtn).on('click', (e) => {
         if (!$(weekdayCalendar).is(':visible') && !btnState) {
@@ -226,7 +226,10 @@ function bindSelectDayPickButton() {
         } else { btnState = false; }
     });
     $(weekdayCalendar).on('focusout', (e) => {
-        if (e.relatedTarget && $(e.relatedTarget).is(weekdayPopupBtn)) {
+        if ($(e.relatedTarget).is(weekdayCalendar) || 
+            $(e.relatedTarget).is($(weekdayCalendar).find('input'))) {
+            return;
+        } else if ($(e.relatedTarget).is(weekdayPopupBtn)) {
             $(weekdayCalendar).hide();
         } else {
             $(weekdayCalendar).hide();
@@ -235,5 +238,5 @@ function bindSelectDayPickButton() {
     });
     $(weekdayPopupCloseBtn).on('click', (e) => { 
         $(weekdayCalendar).trigger('focusout');
-    })
+    });
 }

--- a/respa_admin/static_src/js/reportForm.js
+++ b/respa_admin/static_src/js/reportForm.js
@@ -214,18 +214,26 @@ function bindGenerateButton() {
 }
 
 
+let btnState = false;
 function bindSelectDayPickButton() {
-    let weekdayCalendar = $("ul[id=weekday-cal-popup]");
+    let weekdayCalendar = $("ul[id=weekday-cal-popup]").parent();
     let weekdayPopupBtn = $("a[id=weekday-cal-btn]");
     let weekdayPopupCloseBtn = $("i[id=popup-close-btn]")
     $(weekdayPopupBtn).on('click', (e) => {
-        if (!$(weekdayCalendar).parent().is(':visible')) {
-            $(weekdayCalendar).parent().fadeIn('fast');
+        if (!$(weekdayCalendar).is(':visible') && !btnState) {
+            btnState = true;
+            $(weekdayCalendar).fadeIn('fast').trigger('focus');
+        } else { btnState = false; }
+    });
+    $(weekdayCalendar).on('focusout', (e) => {
+        if (e.relatedTarget && $(e.relatedTarget).is(weekdayPopupBtn)) {
+            $(weekdayCalendar).hide();
         } else {
-            $(weekdayCalendar).parent().fadeOut('fast');
+            $(weekdayCalendar).hide();
+            btnState = false;
         }
     });
-    $(weekdayPopupCloseBtn).on('click', (e) => {
-        $(weekdayCalendar).parent().fadeOut('fast');
+    $(weekdayPopupCloseBtn).on('click', (e) => { 
+        $(weekdayCalendar).trigger('focusout');
     })
 }

--- a/respa_admin/static_src/styles/page-reports.scss
+++ b/respa_admin/static_src/styles/page-reports.scss
@@ -167,3 +167,54 @@
     width: 54px;
     max-width: 54px;
 }
+
+.reports-weekday-calendar {
+    position: relative;
+    width: 0;
+    height: 0;
+    display: none;
+    ul {
+        top: -60px;
+        display: flex;
+        flex-direction: row;
+        position: absolute;
+        min-width: 280px;
+        height: 50px;
+        border: 2px solid black;
+        padding: 0;
+        
+        .calendar-header {
+            width: calc(100% + 4px);
+            height: 25px;
+            position: absolute;
+            top: -25px;
+            right: -2px;
+            border-top: 2px solid black;
+            border-right: 2px solid black;
+            border-left: 2px solid black;
+            border-bottom: none;
+
+            display: flex;
+            justify-content: flex-end;
+
+            i {
+                margin-right: 5px;
+                margin-top: 2px;
+                cursor: pointer;
+            }
+        }
+
+        li {
+            list-style-type: none;
+            min-width: 40px;
+
+            label {
+                text-align: center;
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                * { cursor: pointer; }
+            }
+        }
+    }
+}

--- a/respa_admin/static_src/styles/page-reports.scss
+++ b/respa_admin/static_src/styles/page-reports.scss
@@ -186,15 +186,14 @@
         padding: 0;
         
         .calendar-header {
+            background-color: lightskyblue;
             width: calc(100% + 4px);
             height: 25px;
             position: absolute;
             top: -25px;
             right: -2px;
-            border-top: 2px solid black;
-            border-right: 2px solid black;
-            border-left: 2px solid black;
-            border-bottom: none;
+            border: 2px solid black;
+            border-bottom: 1px solid black;
 
             display: flex;
             justify-content: flex-end;

--- a/respa_admin/static_src/styles/page-reports.scss
+++ b/respa_admin/static_src/styles/page-reports.scss
@@ -174,12 +174,14 @@
     height: 0;
     display: none;
     ul {
-        top: -60px;
+        top: -115px;
+        left: -46.5px;
         display: flex;
-        flex-direction: row;
+        flex-flow: row wrap;
         position: absolute;
-        min-width: 280px;
-        height: 50px;
+        min-width: 220px;
+        max-width: 220px;
+        min-height: 110px;
         border: 2px solid black;
         padding: 0;
         

--- a/respa_admin/templates/respa_admin/page_reports.html
+++ b/respa_admin/templates/respa_admin/page_reports.html
@@ -85,7 +85,7 @@
                     <div class="input-group">
                         <button id="weekday-cal-btn" class="btn btn-default border-thick">
                             <i class="glyphicon glyphicon-calendar"></i>
-                            {% trans 'Weekday'|title %}
+                            {% trans 'Weekdays'|title %}
                         </button>
                     </div>
                 </div>

--- a/respa_admin/templates/respa_admin/page_reports.html
+++ b/respa_admin/templates/respa_admin/page_reports.html
@@ -83,7 +83,7 @@
                         </ul>
                     </div>
                     <div class="input-group">
-                        <button id="weekday-cal-btn" class="btn btn-default border-thick" tabindex="-1">
+                        <button id="weekday-cal-btn" class="btn btn-default border-thick">
                             <i class="glyphicon glyphicon-calendar"></i>
                             {% trans 'Weekday'|title %}
                         </button>

--- a/respa_admin/templates/respa_admin/page_reports.html
+++ b/respa_admin/templates/respa_admin/page_reports.html
@@ -83,10 +83,10 @@
                         </ul>
                     </div>
                     <div class="input-group">
-                        <a id="weekday-cal-btn" class="btn input-group-addon border-thick" tabindex="-1">
+                        <button id="weekday-cal-btn" class="btn btn-default border-thick" tabindex="-1">
                             <i class="glyphicon glyphicon-calendar"></i>
                             {% trans 'Weekday'|title %}
-                        </a>
+                        </button>
                     </div>
                 </div>
             </div>

--- a/respa_admin/templates/respa_admin/page_reports.html
+++ b/respa_admin/templates/respa_admin/page_reports.html
@@ -51,14 +51,43 @@
         </div>
         {% include "respa_admin/common/_paginated_resource_list.html" with resources=resources per_page=20 paginator_id=random_id_str %}
         <div class="col-wrap-container row-wrap space-between">
-            <div class="col-wrap-container">
+            <div class="col-wrap-container fluid row-wrap space-between">
                 <div class="col-wrap-container">
                     <input type="date" class="margin-sm-left border-thick align-center" name="begin-date" id="begin-date" />
-                    <label for="begin-date" class="control-label input-label align-center">{% trans "Start date" %}</label>
+                    <label for="begin-date" class="control-label input-label align-center no-select">{% trans "Start date" %}</label>
                 </div>
                 <div class="col-wrap-container">
                     <input type="date" class="margin-sm-left border-thick align-center" name="end-date" id="end-date" />
-                    <label for="end-date" class="control-label input-label align-center">{% trans "End date" %}</label>
+                    <label for="end-date" class="control-label input-label align-center no-select">{% trans "End date" %}</label>
+                </div>
+                <div class="form-group col-wrap-container margin-sm-left">
+                    <div class="reports-weekday-calendar">
+                        <ul id="weekday-cal-popup">
+                            <div class="calendar-header">
+                                <i id="popup-close-btn" class="glyphicon glyphicon-remove small-text"></i>
+                            </div>
+                            {% for weekday in WEEKDAYS %}
+                            <li>
+                                <label class="control-label input-label align-center no-select">
+                                    <input 
+                                        id="{{ weekday.day }}"
+                                        class="margin-sm-left border-thick align-center"
+                                        type="checkbox" 
+                                        title="{{ weekday.day|title }}"
+                                        data-value="{{ weekday.value }}" 
+                                        checked />
+                                    <span>{% trans weekday.short|title %}</span>
+                                 </label>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    <div class="input-group">
+                        <a id="weekday-cal-btn" class="btn input-group-addon border-thick">
+                            <i class="glyphicon glyphicon-calendar"></i>
+                            {% trans 'Weekday'|title %}
+                        </a>
+                    </div>
                 </div>
             </div>
             <div class="button-container row-reverse align-center">

--- a/respa_admin/templates/respa_admin/page_reports.html
+++ b/respa_admin/templates/respa_admin/page_reports.html
@@ -61,7 +61,7 @@
                     <label for="end-date" class="control-label input-label align-center no-select">{% trans "End date" %}</label>
                 </div>
                 <div class="form-group col-wrap-container margin-sm-left">
-                    <div class="reports-weekday-calendar">
+                    <div class="reports-weekday-calendar" tabindex="-1">
                         <ul id="weekday-cal-popup">
                             <div class="calendar-header">
                                 <i id="popup-close-btn" class="glyphicon glyphicon-remove small-text"></i>
@@ -83,7 +83,7 @@
                         </ul>
                     </div>
                     <div class="input-group">
-                        <a id="weekday-cal-btn" class="btn input-group-addon border-thick">
+                        <a id="weekday-cal-btn" class="btn input-group-addon border-thick" tabindex="-1">
                             <i class="glyphicon glyphicon-calendar"></i>
                             {% trans 'Weekday'|title %}
                         </a>

--- a/respa_admin/views/reports.py
+++ b/respa_admin/views/reports.py
@@ -1,12 +1,9 @@
-from django.http import HttpResponse, HttpResponseRedirect
-from django.urls import reverse_lazy
-from django.utils.translation import ugettext as _
+from django.utils.translation import override as translation_override, ugettext as _
 from django.views.generic.base import TemplateView
-from resources.models import Unit, UnitAuthorization, Resource
+from resources.models import Unit, UnitAuthorization, Resource, Day
 from resources.auth import is_general_admin
 from resources.models.utils import generate_id
 from respa_admin.views.base import ExtraContextMixin
-
 
 
 class ReportView(ExtraContextMixin, TemplateView):
@@ -32,6 +29,8 @@ class ReportView(ExtraContextMixin, TemplateView):
                 if unit.id in self.query_params:
                     setattr(unit, 'checked', True)
         context['random_id_str'] = generate_id()
+        with translation_override('en'):
+            context['WEEKDAYS'] = [dict(value=value, day=day, short=day[:3]) for value, day in Day.DAYS_OF_WEEK]
         return context
 
 


### PR DESCRIPTION
# ra/reports page weekday selector

## Add weekday selector for reports

### [Trello card](https://trello.com/c/yKlymDT4)

-----------------------------------------------------------------------------------------------
### Breakdown:

[Ref. files tab for detailed changes.](https://github.com/City-of-Turku/respa/pull/210/files)

#### Reports
 1. resources/api/reservation.py
     * Filter reservations with selected weekdays with query param "weekdays"
   
 2. resources/models/utils.py
     * Skip resource opening days that are not selected weekdays
    
 3. *.html, *.scss, *.js
     * Weekday calendar
  