### PR TITLE
added rounded_price to orderline serializer

### DIFF
--- a/payments/api/base.py
+++ b/payments/api/base.py
@@ -47,16 +47,33 @@ class OrderLineSerializer(serializers.ModelSerializer):
     product = serializers.SlugRelatedField(queryset=Product.objects.current(), slug_field='product_id')
     price = serializers.SerializerMethodField(read_only=True)
     unit_price = serializers.CharField(source='get_unit_price', read_only=True)
+    rounded_price = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = OrderLine
-        fields = ('product', 'quantity', 'unit_price', 'price')
+        fields = ('product', 'quantity', 'unit_price', 'price', 'rounded_price')
 
     def get_taxfree_price(self, obj):
         return obj.get_detailed_price()
 
     def get_price(self, obj):
+        """
+        Returns the unrounded Decimal price of this orderline.
+        e.g. 1.9999999999999999
+        """
         return obj.get_price(rounded=False)
+
+    def get_rounded_price(self, obj) -> str:
+        """
+        Returns the rounded price of this orderline with 2 decimal places.
+        e.g. '2.00'
+        """
+        detailed_prices = obj.get_detailed_price()
+        price = 0
+        for x in detailed_prices:
+            temp = detailed_prices[x]['tax_total'] + detailed_prices[x]['taxfree_price_total']
+            price += temp
+        return '{:.2f}'.format(price)
 
     def to_representation(self, instance):
         data = super().to_representation(instance)

--- a/payments/tests/test_order_api.py
+++ b/payments/tests/test_order_api.py
@@ -17,7 +17,7 @@ PRICE_ENDPOINT_ORDER_FIELDS = {
 }
 
 ORDER_LINE_FIELDS = {
-    'product', 'quantity', 'price', 'unit_price'
+    'product', 'quantity', 'price', 'unit_price', 'rounded_price'
 }
 
 PRODUCT_FIELDS = {


### PR DESCRIPTION
# Added rounded_price to orderline serializer


#### Added new `rounded_price` field to the `orderline` serializer. The `rounded_price` contains a string showing the price of the orderline with 2 decimal places, e.g. '2.00'.
[Trello card related to this fix](https://trello.com/c/oXEiRfLI/328-korjataan-varaamon-tuotesivulla-yhteens%C3%A4-hintojen-py%C3%B6ristyksen-puuttuminen-ja-puuttuvat-desimaalit)

-----------------------------------------------------------------------------------------------
Changes:
- **payments/api/base.py**
Added new `rounded_price` field which is a string displaying the price of the orderline with 2 decimal places, e.g. '2.00'.

- **payments/tests/test_order_api.py**
Added the new `rounded_price` to `ORDER_LINE_FIELDS` which is used to check that responses contain the correct fields.

