### PR TITLE
Remove broken & unused status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GitHub Actions](https://github.com/codepointtku/respa/actions/workflows/respa.yml/badge.svg?branch=develop)](https://github.com/codepointtku/respa/actions/workflows/respa.yml)
+[![GitHub Actions](https://github.com/city-of-turku/respa/actions/workflows/respa.yml/badge.svg?branch=develop)](https://github.com/city-of-turku/respa/actions/workflows/respa.yml)
 [![codecov](https://codecov.io/gh/codepointtku/respa/branch/develop/graph/badge.svg)](https://codecov.io/gh/codepointtku/respa)
 
 Respa – Resource reservation and management service

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-[![Travis CI](https://travis-ci.com/codepointtku/respaTku.svg?branch=master)](https://travis-ci.com/codepointtku/respa)
 [![GitHub Actions](https://github.com/codepointtku/respa/actions/workflows/respa.yml/badge.svg?branch=develop)](https://github.com/codepointtku/respa/actions/workflows/respa.yml)
 [![codecov](https://codecov.io/gh/codepointtku/respa/branch/develop/graph/badge.svg)](https://codecov.io/gh/codepointtku/respa)
-[![Requirements Status](https://requires.io/github/codepointtku/respa/requirements.svg?branch=develop)](https://requires.io/github/codepointtku/respa/requirements/?branch=develop)
 
 Respa – Resource reservation and management service
 ===================


### PR DESCRIPTION
# Remove broken & unused status badges

-----------------------------------------------------------------------------------------------
### Breakdown:

We don't use travis and requires.io has stopped its services