### PR TITLE
Fixed reservation updates with overlap restriction

### DIFF
--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -443,6 +443,11 @@ class Reservation(ModifiableModel):
                 reservations_for_same_unit = Reservation.objects.filter(user=user, resource__unit=self.resource.unit)
             else:
                 reservations_for_same_unit = Reservation.objects.filter(resource__unit=self.resource.unit)
+
+            original = kwargs.get('original_reservation', None)
+            if original:
+                reservations_for_same_unit = reservations_for_same_unit.exclude(id=original.id)
+
             valid_reservations_for_same_unit = reservations_for_same_unit.exclude(state=Reservation.CANCELLED)
             user_has_conflicting_reservations = valid_reservations_for_same_unit.filter(
                 Q(begin__gt=self.begin, begin__lt=self.end)
@@ -556,7 +561,7 @@ class Reservation(ModifiableModel):
                 ground_plan_image_url = ground_plan_image.get_full_url()
                 if ground_plan_image_url:
                     context['resource_ground_plan_image_url'] = ground_plan_image_url
-            
+
             universal_data = getattr(self, 'universal_data', None)
             if universal_data:
                 # reservation contains universal_data
@@ -661,7 +666,7 @@ class Reservation(ModifiableModel):
                                 else:
                                     # only 1 of the product
                                     product['product_quantity'] = float(1)
-                                
+
                             values = calculate_final_product_sums(product=item, quantity=conditional_quantity)
                             product['product_taxfree_total'] = values['product_taxfree_total']
                             product['product_tax_total'] = values['product_tax_total']

--- a/resources/tests/conftest.py
+++ b/resources/tests/conftest.py
@@ -79,6 +79,15 @@ def test_unit3():
 
 
 @pytest.fixture
+def test_unit4():
+    return Unit.objects.create(
+            name="unit 4",
+            time_zone='Europe/Helsinki',
+            disallow_overlapping_reservations=True
+        )
+
+
+@pytest.fixture
 def generic_terms():
     return TermsOfUse.objects.create(
         name_fi='testikäyttöehdot',
@@ -144,6 +153,53 @@ def resource_in_unit3(space_resource_type, test_unit3):
         max_period=datetime.timedelta(hours=4),
         reservable=True,
     )
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def resource_in_unit4_1(space_resource_type, test_unit4):
+    resource = Resource.objects.create(
+        type=space_resource_type,
+        authentication="none",
+        name="resource in unit 4 first",
+        unit=test_unit4,
+        max_reservations_per_user=5,
+        max_period=datetime.timedelta(hours=4),
+        reservable=True,
+    )
+    p1 = Period.objects.create(start=datetime.date(2115, 1, 1),
+                               end=datetime.date(2115, 12, 31),
+                               resource=resource, name='regular hours')
+    for weekday in range(0, 7):
+        Day.objects.create(period=p1, weekday=weekday,
+                           opens=datetime.time(8, 0),
+                           closes=datetime.time(18, 0))
+    resource.update_opening_hours()
+    return resource
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def resource_in_unit4_2(space_resource_type, test_unit4):
+    resource = Resource.objects.create(
+        type=space_resource_type,
+        authentication="none",
+        name="resource in unit 4 second",
+        unit=test_unit4,
+        max_reservations_per_user=5,
+        max_period=datetime.timedelta(hours=4),
+        reservable=True,
+    )
+    p1 = Period.objects.create(start=datetime.date(2115, 1, 1),
+                               end=datetime.date(2115, 12, 31),
+                               resource=resource, name='regular hours')
+    for weekday in range(0, 7):
+        Day.objects.create(period=p1, weekday=weekday,
+                           opens=datetime.time(8, 0),
+                           closes=datetime.time(18, 0))
+    resource.update_opening_hours()
+    return resource
+
 
 @pytest.mark.django_db
 @pytest.fixture
@@ -304,6 +360,22 @@ def unit_manager_user(resource_in_unit):
     )
     user.unit_authorizations.create(subject=resource_in_unit.unit, level=UnitAuthorizationLevel.manager)
     return user
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def unit4_manager_user(resource_in_unit4_1):
+    user = get_user_model().objects.create(
+        username='test_manager_user',
+        first_name='Inspector',
+        last_name='Lestrade',
+        email='lestrade@scotlandyard.co.uk',
+        is_staff=True,
+        preferred_language='en'
+    )
+    user.unit_authorizations.create(subject=resource_in_unit4_1.unit, level=UnitAuthorizationLevel.manager)
+    return user
+
 
 @pytest.mark.django_db
 @pytest.fixture


### PR DESCRIPTION
# Fix to reservation updates with overlap restriction

## Fixed users not able to update their reservation when reservation's unit has reservation overlap restriction

### [Related Trello card](https://trello.com/c/y7Cl8mGp)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Unit reservation overlap rules
 1. resources/models/reservation.py
     * excluded the reservation to be updated from being compared against itself in overlap check