### PR TITLE
Fixed unit reservation partial overlap check

### DIFF
--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -453,6 +453,7 @@ class Reservation(ModifiableModel):
                 Q(begin__gt=self.begin, begin__lt=self.end)
                 | Q(begin__lt=self.begin, end__gt=self.begin)
                 | Q(begin__gte=self.begin, end__lte=self.end)
+                | Q(begin__lte=self.begin, end__gt=self.end)
             )
 
             if user_has_conflicting_reservations:


### PR DESCRIPTION
# Fixed unit reservation partial overlap restriction check

## Fixed unit overlap restriction check allowing partial overlaps when overlapping reservation ends before already existing reservation e.g. reservation 9-10 and reservation 9-9.30 would be allowed

### [Related Trello card](https://trello.com/c/YYdBxaGI)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Fix to unit overlap restriction check
 1. resources/models/reservation.py
     * added new query filter to better handle overlap checks