### PR TITLE
RA - Unit street bugfix

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1832,7 +1832,7 @@ msgid "Remove time period"
 msgstr ""
 
 #: respa_admin/templates/respa_admin/forms/_form_errors.html:5
-msgid "Tarkista seuraavat virheet"
+msgid "Check the following errors"
 msgstr ""
 
 #: respa_admin/templates/respa_admin/forms/_image.html:7

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1309,8 +1309,8 @@ msgstr "Aikaväli"
 msgid "Remove time period"
 msgstr "Poista ajanjakso"
 
-msgid "Tarkista seuraavat virheet"
-msgstr "Check the following errors"
+msgid "Check the following errors"
+msgstr "Tarkista seuraavat virheet"
 
 msgid "Choose image"
 msgstr "Valitse kuva"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -1313,7 +1313,7 @@ msgstr "Tidsintervall"
 msgid "Remove time period"
 msgstr "Ta bort tidsperiod"
 
-msgid "Tarkista seuraavat virheet"
+msgid "Check the following errors"
 msgstr "Kontrollera följande fel"
 
 msgid "Choose image"

--- a/resources/api/unit.py
+++ b/resources/api/unit.py
@@ -146,7 +146,9 @@ class UnitSerializer(ExtraDataMixin, TranslatedModelSerializer):
                     not has_permission(user, 'resources.view_unit')):
                         del ret['created_by']
                         del ret['modified_by']
-
+        if 'street_address' in ret:
+            if isinstance(ret['street_address'], dict) and not ret['street_address']:
+                ret['street_address'] = None
         return ret
 
     

--- a/resources/api/unit.py
+++ b/resources/api/unit.py
@@ -146,9 +146,6 @@ class UnitSerializer(ExtraDataMixin, TranslatedModelSerializer):
                     not has_permission(user, 'resources.view_unit')):
                         del ret['created_by']
                         del ret['modified_by']
-        if 'street_address' in ret:
-            if isinstance(ret['street_address'], dict) and not ret['street_address']:
-                ret['street_address'] = None
         return ret
 
     

--- a/respa_admin/forms.py
+++ b/respa_admin/forms.py
@@ -386,6 +386,10 @@ class UnitForm(forms.ModelForm):
         label='Nimi [fi]',
     )
 
+    street_address_fi = forms.CharField(
+        required=True,
+        label=f"{_('Street address')} [fi]"
+    )
     class Meta:
         model = Unit
 

--- a/respa_admin/templates/respa_admin/forms/_form_errors.html
+++ b/respa_admin/templates/respa_admin/forms/_form_errors.html
@@ -3,10 +3,14 @@
 
 {% if form.errors or resource_image_formset.errors or period_formset_with_days.errors or resource_options_formset.errors or resource_universal_formset.errors %}
     <div class="alert alert-danger">
-        <strong>{% trans "Tarkista seuraavat virheet" %}:</strong>
+        <strong>{% trans "Check the following errors" %}:</strong>
             {% if form.errors|is_truthy %}
             <div>
-                <strong>{% trans "Resource"|capfirst %}</strong>
+                {% if not IS_UNIT_PAGE %}
+                <strong>{% trans "resource"|capfirst %}</strong>
+                {% else %}
+                <strong>{% trans "unit"|capfirst %}</strong>
+                {% endif %}
             </div>
             <ul>
                 {% for error in form.errors|remove_empty %}

--- a/respa_admin/templatetags/templatetags.py
+++ b/respa_admin/templatetags/templatetags.py
@@ -46,7 +46,7 @@ def user_has_permission(user, permission, obj):
 
 @register.filter
 def is_truthy(collection):
-    return any([bool(value) for value in collection])
+    return any([bool(value) for value in collection or []])
 
 
 @register.filter

--- a/respa_admin/tests/conftest.py
+++ b/respa_admin/tests/conftest.py
@@ -220,7 +220,7 @@ def test_unit_form_data(test_unit, empty_unit_form_data, empty_period_form_data,
         'municipality': municipality.pk,
         'name': test_unit.name or '',
         'phone': test_unit.phone or '',
-        'street_address': test_unit.street_address or '',
+        'street_address_fi': test_unit.street_address_fi or 'Some street',
         'www_url': test_unit.www_url or '',
     })
     empty_unit_form_data.update(empty_period_form_data)

--- a/respa_admin/views/units.py
+++ b/respa_admin/views/units.py
@@ -152,6 +152,7 @@ class UnitEditView(ExtraContextMixin, PeriodMixin, CreateView):
                 period_formset_with_days=period_formset_with_days,
                 trans_fields=trans_fields,
                 page_headline=_('Edit Unit'),
+                IS_UNIT_PAGE=True
             )
         )
 


### PR DESCRIPTION
# RA - Unit street bugfix

### [Trello card](https://trello.com/c/nqh4es4e)

-----------------------------------------------------------------------------------------------

[Ref. files tab for changes.](https://github.com/City-of-Turku/respa/pull/244/files)

##### Fixes a bug that allows unit street address to be none, causing [Varaamo](https://github.com/City-of-Turku/respa/) to crash