### PR TITLE
fixed typo in ical file text

### DIFF
--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -803,7 +803,7 @@ class Reservation(ModifiableModel):
         if self.resource.resource_staff_emails:
             reservations = [self]
             ical_file = build_reservations_ical_file(reservations)
-            attachment = ('reservation.icss', ical_file, 'text/calendar')
+            attachment = ('reservation.ics', ical_file, 'text/calendar')
             for email in self.resource.resource_staff_emails:
                 self.send_reservation_mail(notification, staff_email=email, attachments=[attachment])
         else:


### PR DESCRIPTION
# Fixed typo in ical file ending


### Text containing the name+ending of the file contained a typo which caused the ical file to not work.

-----------------------------------------------------------------------------------------------
Changes:
- resources/models/reservation.py:
Fixed typo in ical file creation.