### PR TITLE
Fixed modified email sending when only commenting

### DIFF
--- a/payments/tests/test_reservation_api.py
+++ b/payments/tests/test_reservation_api.py
@@ -401,7 +401,7 @@ def test_cash_paid_reservation_process_flow_works_correctly(
     )
 
     # user updates their reservation
-    reservation_data.update({'reserver_name': 'Test Tester'})
+    reservation_data.update({'end': '2115-04-04T12:30:00+02:00'})
     response = user_api_client.put(get_detail_url(new_reservation), reservation_data)
     assert response.status_code == 200
     assert response.data['state'] == Reservation.REQUESTED

--- a/resources/tests/conftest.py
+++ b/resources/tests/conftest.py
@@ -11,6 +11,7 @@ from resources.models import Resource, ResourceType, Unit, Purpose, Day, Period
 from resources.models import Equipment, EquipmentAlias, ResourceEquipment, EquipmentCategory, TermsOfUse, ResourceGroup
 from resources.models import AccessibilityValue, AccessibilityViewpoint, ResourceAccessibility, UnitAccessibility, MaintenanceMessage
 from resources.models import ResourceUniversalFormOption, ResourceUniversalField, UniversalFormFieldType
+from resources.models import ReservationMetadataSet, ReservationMetadataField
 from munigeo.models import Municipality
 
 
@@ -105,6 +106,30 @@ def payment_terms():
         text_fi='kaikki on maksullista',
         text_en='everything is chargeable',
         terms_type=TermsOfUse.TERMS_TYPE_PAYMENT
+    )
+
+@pytest.fixture
+def metadataset_1():
+    name_field = ReservationMetadataField.objects.get(field_name='reserver_name')
+    email_field = ReservationMetadataField.objects.get(field_name='reserver_email_address')
+    phone_field = ReservationMetadataField.objects.get(field_name='reserver_phone_number')
+    metadata_set = ReservationMetadataSet.objects.create(
+        name='test_metadataset_1',
+        )
+    metadata_set.supported_fields.set([name_field, email_field, phone_field])
+    return metadata_set
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def resource_with_metadata(space_resource_type, metadataset_1, test_unit):
+    return Resource.objects.create(
+        type=space_resource_type,
+        authentication="none",
+        name="resource with metadata",
+        reservation_metadata_set=metadataset_1,
+        unit=test_unit,
+        reservable=True,
     )
 
 


### PR DESCRIPTION
# Reservation modified emails when only comments change

## Reservation modified emails are now only sent if reservation metadata or times change. This fixes unwanted emails from being sent to users for example when staff only adds a comment to reservation, an email should not be sent to the client because the client cannot see comments in their emails.

### [Related Trello card](https://trello.com/c/6C3xVaz9)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### modified email sending logic
 1. resources/api/reservation.py
     * send modified email only when metadata or times changed for reservation
   
 2. resources/models/utils.py
     * added function to tell whether reservation metadata or times are different between given reservation instances