### PR TITLE
Process missing name translations

### DIFF
--- a/qualitytool/api/serializers/external.py
+++ b/qualitytool/api/serializers/external.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from django.conf import settings
 
 def form_languages():
     from qualitytool import models
@@ -20,5 +21,19 @@ class QualityToolFormSerializer(serializers.Serializer):
 
 
 class QualityToolTargetListSerializer(serializers.Serializer):
-    name = serializers.DictField(child=serializers.CharField(), required=False)
+    name = serializers.DictField(child=serializers.CharField(required=False))
     targetId = serializers.UUIDField(required=False)
+
+    def to_internal_value(self, data):
+        self._process_target_name(data)
+        return super().to_internal_value(data)
+    
+    def _process_target_name(self, data : dict):
+        """
+        Some language fields might not exist, 
+        Find existing one and use it as a default.
+        """
+        name = data['name']
+        nonvalues = [lang for lang, _ in settings.LANGUAGES if not name.get(lang, None)]
+        default = next(iter(lang for lang, _ in name.items() if name.get(lang, None)))
+        name.update({lang: name[default] for lang in nonvalues})


### PR DESCRIPTION
# Process missing name translations

## Instead of throwing an error, use the available name with other languages.

### [Trello](https://trello.com/c/Mirjc0sj)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### API
 1. qualitytool/api/serializers/external.py 
     * Process provided name.
  
