### PR TITLE
Bugfix: Django admin order view

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -439,7 +439,7 @@ class Product(models.Model):
 
         price = self.price if not product_cg else product_cg.price
         time_slot_prices = TimeSlotPrice.objects.filter(product=self)
-        tz = self.resources.first().unit.get_tz()
+        tz = self.resources.with_soft_deleted.first().unit.get_tz()
         local_tz_begin = begin.astimezone(tz)
         local_tz_end = end.astimezone(tz)
         if self.price_type == Product.PRICE_FIXED:
@@ -494,7 +494,7 @@ class Product(models.Model):
         price = self.price if not product_cg else product_cg.price
         price_tax_free = self.price_tax_free if not product_cg else product_cg.price_tax_free
         time_slot_prices = TimeSlotPrice.objects.filter(product=self)
-        tz = self.resources.first().unit.get_tz()
+        tz = self.resources.with_soft_deleted.first().unit.get_tz()
         local_tz_begin = begin.astimezone(tz)
         local_tz_end = end.astimezone(tz)
         # dict with keys for each unique price.


### PR DESCRIPTION
# Bugfix: Django admin order view

## Fix django admin order view crashing due to soft deleted resources not being included in queryset

### [Trello card](https://trello.com/c/FGdma27T)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Queryset
 1. payments/models.py 
     * Include soft deleted resources to queryset
   
