### PR TITLE
Changed RA fi universal fields visibility

### DIFF
--- a/respa_admin/static_src/js/resourceFormLanguage.js
+++ b/respa_admin/static_src/js/resourceFormLanguage.js
@@ -10,13 +10,25 @@ export function toggleLanguage(language) {
   let $languageButtons = $('[name$="language-' + language + '"]');
 
   $languageInputs.each(
-    (i, input) =>
-      (input.classList.contains('hidden')) ? input.classList.remove('hidden') : input.classList.add('hidden')
+    (i, input) => {
+      if (input.classList.contains('hidden')) {
+        input.classList.remove('hidden')
+      }
+      else if (!input.classList.contains('always-show')) {
+        input.classList.add('hidden')
+      }
+    }
   );
 
   $languageLabels.each(
-    (i, input) =>
-      (input.classList.contains('hidden')) ? input.classList.remove('hidden') : input.classList.add('hidden')
+    (i, input) => {
+      if (input.classList.contains('hidden')) {
+        input.classList.remove('hidden')
+      }
+      else if (!input.classList.contains('always-show')) {
+        input.classList.add('hidden')
+      }
+    }
   );
 
   $languageButtons.each(
@@ -61,7 +73,7 @@ export function calculateTranslatedFields() {
     const $languageButton = $('[name="language-' + language + '"]');
     const currentCountForLanguage = $languageButton.find('span').text();
     const UNICODE_CHECKMARK = '\u2713'
-    if(currentCountForLanguage - languageCount === 0) {
+    if (currentCountForLanguage - languageCount === 0) {
       $languageButton.find('span').css('background-color', '#23a000').text(UNICODE_CHECKMARK);
     }
     else {
@@ -87,8 +99,16 @@ function hideLanguage(language, input = null) {
     $languageLabels = $('[for$="_' + language + '"]');
   }
 
-  $languageInputs.each((i, input) => input.classList.add('hidden'));
-  $languageLabels.each((i, input) => input.classList.add('hidden'));
+  $languageInputs.each((i, input) => {
+    if (!input.classList.contains('always-show')) {
+      input.classList.add('hidden');
+    }
+  });
+  $languageLabels.each((i, input) => {
+    if (!input.classList.contains('always-show')) {
+      input.classList.add('hidden');
+    }
+  });
 }
 
 

--- a/respa_admin/templates/respa_admin/forms/_input.html
+++ b/respa_admin/templates/respa_admin/forms/_input.html
@@ -1,6 +1,6 @@
 <div class="form-group">
     <label
-        class="control-label input-label"
+        class="control-label input-label{% if always_show %} always-show{% endif %}"
         for="{{ field.id_for_label }}"
     >
         {{ field.label }}{% if field.field.required %}*{% endif %}
@@ -16,7 +16,7 @@
         {% if field.value != None %}
             value="{{ field.value|stringformat:'s' }}"
         {% endif %}
-        class="form-control text-input"
+        class="form-control text-input{% if always_show %} always-show{% endif %}"
         {% include "django/forms/widgets/attrs.html" %}
         {% if field.field.disabled %} disabled="disabled" {% endif %}
     >

--- a/respa_admin/templates/respa_admin/forms/_textarea_input.html
+++ b/respa_admin/templates/respa_admin/forms/_textarea_input.html
@@ -1,7 +1,7 @@
 <div class="form-group">
     <div class="textarea-wrapper">
         <label
-            class="control-label input-label"
+            class="control-label input-label{% if always_show %} always-show{% endif %}"
             for="{{ field.id_for_label }}"
         >
             {{ field.label }}{% if field.field.required %}*{% endif %}
@@ -9,7 +9,7 @@
         <div class="textarea-with-toolbar">
             <textarea
                 id="{{ field.id_for_label }}"
-                class="form-control"
+                class="form-control{% if always_show %} always-show{% endif %}"
                 rows="5"
                 name="{{ field.html_name }}"
                 {% if field.field.disabled %} disabled="disabled" {% endif %}

--- a/respa_admin/templates/respa_admin/resources/form/_options.html
+++ b/respa_admin/templates/respa_admin/resources/form/_options.html
@@ -39,7 +39,7 @@
                 {% include "respa_admin/forms/_input.html" with field=uni_form.sort_order %}
             </div>
             <div class="input-row uni-row">
-                {% include "respa_admin/forms/_textarea_input.html" with field=uni_form.text_fi %}
+                {% include "respa_admin/forms/_textarea_input.html" with field=uni_form.text_fi always_show=True %}
                 {% include "respa_admin/forms/_textarea_input.html" with field=uni_form.text_en %}
                 {% include "respa_admin/forms/_textarea_input.html" with field=uni_form.text_sv %}
             </div>

--- a/respa_admin/templates/respa_admin/resources/form/_universal.html
+++ b/respa_admin/templates/respa_admin/resources/form/_universal.html
@@ -43,13 +43,13 @@
                 {% include "respa_admin/forms/_input.html" with field=uni_form.name %}
             </div>
             <div class="input-row uni-row">
-                {% include "respa_admin/forms/_input.html" with field=uni_form.label_fi %}
+                {% include "respa_admin/forms/_input.html" with field=uni_form.label_fi always_show=True %}
                 {% include "respa_admin/forms/_input.html" with field=uni_form.label_en %}
                 {% include "respa_admin/forms/_input.html" with field=uni_form.label_sv %}
             </div>
 
             <div class="input-row uni-row">
-                {% include "respa_admin/forms/_textarea_input.html" with field=uni_form.description_fi %}
+                {% include "respa_admin/forms/_textarea_input.html" with field=uni_form.description_fi always_show=True %}
                 {% include "respa_admin/forms/_textarea_input.html" with field=uni_form.description_en %}
                 {% include "respa_admin/forms/_textarea_input.html" with field=uni_form.description_sv %}
             </div>


### PR DESCRIPTION
# RA fi universal fields visibility

## RA fi universal fields are now always shown because they are required regardless of language choice

### [Related Trello card](https://trello.com/c/OlKtU6FV)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Force universal field fi fields to be always visible
 1. respa_admin/static_src/js/resourceFormLanguage.js
     * fields with always-show class prevent addition of hidden class
   
 2. respa_admin/templates/respa_admin/forms/_input.html
     * label and input can get always-show class when it is set via context
    
 3. respa_admin/templates/respa_admin/forms/_textarea_input.html
     * label and textarea can get always-show class when it is set via context
 
4. respa_admin/templates/respa_admin/resources/form/_options.html
     * fi options are set to be always shown

 5. respa_admin/templates/respa_admin/resources/form/_universal.html
     * fi universal field label and description are set to be always shown
     

