### PR TITLE
Allowed unit managers to see all reservations

### DIFF
--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -37,14 +37,14 @@ from payments.models import Order
 
 from resources.models import (
     Reservation, Resource, ReservationMetadataSet,
-    ReservationHomeMunicipalityField, ReservationBulk
+    ReservationHomeMunicipalityField, ReservationBulk, Unit
 )
 from resources.models.reservation import RESERVATION_BILLING_FIELDS, RESERVATION_EXTRA_FIELDS
 from resources.models.utils import build_reservations_ical_file
 from resources.pagination import ReservationPagination
 from resources.models.utils import generate_reservation_xlsx, get_object_or_none
 
-from ..auth import is_general_admin, is_underage, is_overage, is_authenticated_user
+from ..auth import is_general_admin, is_underage, is_overage, is_authenticated_user, is_any_admin, is_any_manager
 from .base import (
     NullableDateTimeField, TranslatedModelSerializer, register_view, DRFFilterBooleanWidget,
     ExtraDataMixin
@@ -97,6 +97,7 @@ class ReservationBulkSerializer(ExtraDataMixin, TranslatedModelSerializer):
         fields = [
             'bucket'
         ]
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -106,6 +107,7 @@ class ReservationBulkSerializer(ExtraDataMixin, TranslatedModelSerializer):
             data.append(
                 (res.begin, res.end)
             )
+
 
 class HomeMunicipalitySerializer(TranslatedModelSerializer):
     class Meta:
@@ -129,15 +131,16 @@ class HomeMunicipalitySerializer(TranslatedModelSerializer):
                     raise ValidationError(_('Invalid home municipality object - id is missing.'))
 
             if not home_municipality:
-                    raise ValidationError({
-                        'home_municipality': {
-                            'id': [_('Invalid pk "{pk_value}" - object does not exist.').format(pk_value=data)]
-                        }
-                    })
+                raise ValidationError({
+                    'home_municipality': {
+                        'id': [_('Invalid pk "{pk_value}" - object does not exist.').format(pk_value=data)]
+                    }
+                })
             data = home_municipality
             return data
         else:
             return super().to_internal_value(data)
+
 
 class ReservationSerializer(ExtraDataMixin, TranslatedModelSerializer, munigeo_api.GeoModelSerializer):
     begin = NullableDateTimeField()
@@ -186,7 +189,6 @@ class ReservationSerializer(ExtraDataMixin, TranslatedModelSerializer, munigeo_a
             self.handle_reservation_modify_request(request, resource)
             order = request.data.get('order')
 
-
             begin, end = (request.data.get('begin', None), request.data.get('end', None))
             if not order or isinstance(order, str) or (order and is_free(get_price(order, begin=begin, end=end))):
                 required = [field for field in required if field not in RESERVATION_BILLING_FIELDS]
@@ -207,15 +209,14 @@ class ReservationSerializer(ExtraDataMixin, TranslatedModelSerializer, munigeo_a
 
         self.context.update({'resource': resource})
 
-
     def handle_reservation_modify_request(self, request, resource):
         # handle removing order from data when updating reservation without paying
         if self.instance and resource.has_products() and 'order' in request.data:
             state = request.data.get('state')
             # states where reservation updates can be made
             if state in (
-                Reservation.CONFIRMED, Reservation.CANCELLED, Reservation.DENIED,
-                Reservation.REQUESTED, Reservation.READY_FOR_PAYMENT, Reservation.WAITING_FOR_CASH_PAYMENT):
+                    Reservation.CONFIRMED, Reservation.CANCELLED, Reservation.DENIED,
+                    Reservation.REQUESTED, Reservation.READY_FOR_PAYMENT, Reservation.WAITING_FOR_CASH_PAYMENT):
                 has_staff_perms = resource.is_manager(request.user) or resource.is_admin(request.user)
                 user_can_modify = self.instance.can_modify(request.user)
                 # staff members never pay after reservation creation and their order can be removed safely here
@@ -223,10 +224,8 @@ class ReservationSerializer(ExtraDataMixin, TranslatedModelSerializer, munigeo_a
                 if has_staff_perms or (user_can_modify and state != Reservation.READY_FOR_PAYMENT):
                     del request.data['order']
 
-
     def get_required_fields(self):
         return [field_name for field_name in self.fields if self.fields[field_name].required]
-
 
     def get_extra_fields(self, includes, context):
         from .resource import ResourceInlineSerializer
@@ -338,7 +337,6 @@ class ReservationSerializer(ExtraDataMixin, TranslatedModelSerializer, munigeo_a
         if reserver_phone_number.startswith('+'):
             if not region_code_for_country_code(phonenumbers.parse(reserver_phone_number).country_code):
                 raise ValidationError(dict(reserver_phone_number=_('Invalid country code')))
-
 
         if data.get('staff_event', False):
             if not resource.can_create_staff_event(request_user):
@@ -527,6 +525,7 @@ class ReservationSerializer(ExtraDataMixin, TranslatedModelSerializer, munigeo_a
             'can_delete': can_modify_and_delete,
         }
 
+
 class UserFilterBackend(filters.BaseFilterBackend):
     """
     Filter by user uuid and by is_own.
@@ -601,6 +600,7 @@ class ReservationFilterBackend(filters.BaseFilterBackend):
             queryset = queryset.filter(begin__lte=times['end'])
         return queryset
 
+
 class HasArrivedFilterBackend(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         has_arrived = request.query_params.get('has_arrived', None)
@@ -609,13 +609,16 @@ class HasArrivedFilterBackend(filters.BaseFilterBackend):
             return queryset.filter(has_arrived=has_arrived)
         return queryset
 
+
 class PhonenumberFilterBackend(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         phonenumber = request.query_params.get('reserver_phone_number', '')
         phonenumber = phonenumber.strip()
         if phonenumber and phonenumber.isdigit():
-            queryset = queryset.filter(Q(reserver_phone_number=phonenumber) | Q(reserver_phone_number='+%s' % phonenumber))
+            queryset = queryset.filter(Q(reserver_phone_number=phonenumber) |
+                                       Q(reserver_phone_number='+%s' % phonenumber))
         return queryset
+
 
 class NeedManualConfirmationFilterBackend(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
@@ -730,13 +733,13 @@ class ReservationPermission(permissions.BasePermission):
             resource = Resource.objects.get(pk=resource_id)
         except Resource.DoesNotExist:
             return request.method in permissions.SAFE_METHODS or \
-                    request.user and request.user.is_authenticated
+                request.user and request.user.is_authenticated
 
         if resource.authentication == 'strong' and \
-            not request.user.is_strong_auth:
+                not request.user.is_strong_auth:
             return False
         if request.method in permissions.SAFE_METHODS or \
-            request.user and request.user.is_authenticated:
+                request.user and request.user.is_authenticated:
             return True
         return request.method == 'POST' and resource.authentication == 'unauthenticated'
 
@@ -801,6 +804,7 @@ class ReservationCacheMixin:
         self._preload_permissions()
         return context
 
+
 class ReservationBulkViewSet(viewsets.ModelViewSet, ReservationCacheMixin):
     queryset = ReservationBulk.objects.all()
     permission_classes = (permissions.IsAuthenticatedOrReadOnly, ReservationPermission, permissions.IsAdminUser,)
@@ -814,8 +818,6 @@ class ReservationBulkViewSet(viewsets.ModelViewSet, ReservationCacheMixin):
     def get_queryset(self):
         queryset = super().get_queryset()
         return queryset
-
-
 
     """
     {
@@ -847,9 +849,9 @@ class ReservationBulkViewSet(viewsets.ModelViewSet, ReservationCacheMixin):
             stack[0].pop('resource')
         if len(stack) > 100:
             return JsonResponse({
-                    'status':'false',
-                    'recurring_validation_error': _('Reservation failed. Too many reservations at once.'),
-                }, status=400
+                'status': 'false',
+                'recurring_validation_error': _('Reservation failed. Too many reservations at once.'),
+            }, status=400
             )
         data = {
             **request.data
@@ -864,9 +866,9 @@ class ReservationBulkViewSet(viewsets.ModelViewSet, ReservationCacheMixin):
                 end = key.get('end')
                 if begin is None or end is None:
                     return JsonResponse({
-                            'status':'false',
-                            'recurring_validation_error': _('Reservation failed. Begin or end time is missing.')
-                        }, status=400
+                        'status': 'false',
+                        'recurring_validation_error': _('Reservation failed. Begin or end time is missing.')
+                    }, status=400
                     )
             reservations = []
             for key in stack:
@@ -884,24 +886,24 @@ class ReservationBulkViewSet(viewsets.ModelViewSet, ReservationCacheMixin):
                 res.end = end
                 if resource.validate_reservation_period(res, res.user):
                     return JsonResponse({
-                            'status':'false',
-                            'recurring_validation_error': _('Reservation failed. Make sure reservation period is correct.')
-                        }, status=400
+                        'status': 'false',
+                        'recurring_validation_error': _('Reservation failed. Make sure reservation period is correct.')
+                    }, status=400
                     )
                 if resource.validate_max_reservations_per_user(res.user):
                     return JsonResponse({
-                            'status':'false',
-                            'recurring_validation_error': _('Reservation failed. Too many reservations at once.')
-                        }, status=400
+                        'status': 'false',
+                        'recurring_validation_error': _('Reservation failed. Too many reservations at once.')
+                    }, status=400
                     )
                 if resource.check_reservation_collision(begin, end, res):
                     return JsonResponse({
-                            'status':'false',
-                            'recurring_validation_error': _('Reservation failed. Overlap with existing reservations.')
-                        }, status=400
+                        'status': 'false',
+                        'recurring_validation_error': _('Reservation failed. Overlap with existing reservations.')
+                    }, status=400
                     )
                 reservations.append(res)
-            reservation_dates_context = { 'dates': [] }
+            reservation_dates_context = {'dates': []}
 
             """
             {% if bulk_email_context is defined %}
@@ -915,27 +917,27 @@ class ReservationBulkViewSet(viewsets.ModelViewSet, ReservationCacheMixin):
                 res.state = 'confirmed'
                 if resource.validate_reservation_period(res, res.user):
                     return JsonResponse({
-                            'status':'false',
-                            'recurring_validation_error': _('Reservation failed. Make sure reservation period is correct.')
-                        }, status=400
+                        'status': 'false',
+                        'recurring_validation_error': _('Reservation failed. Make sure reservation period is correct.')
+                    }, status=400
                     )
                 if resource.validate_max_reservations_per_user(res.user):
                     return JsonResponse({
-                            'status':'false',
-                            'recurring_validation_error': _('Reservation failed. Too many reservations at once.')
-                        }, status=400
+                        'status': 'false',
+                        'recurring_validation_error': _('Reservation failed. Too many reservations at once.')
+                    }, status=400
                     )
                 if resource.check_reservation_collision(begin, end, res):
                     return JsonResponse({
-                            'status':'false',
-                            'recurring_validation_error': _('Reservation failed. Overlap with existing reservations.')
-                        }, status=400
+                        'status': 'false',
+                        'recurring_validation_error': _('Reservation failed. Overlap with existing reservations.')
+                    }, status=400
                     )
                 res.save()
                 reservation_dates_context['dates'].append(
                     {
                         'begin': dateparser(reservations[0].begin, res.begin),
-                        'end':  dateparser(reservations[0].end, res.end)
+                        'end': dateparser(reservations[0].end, res.end)
                     }
                 )
 
@@ -952,7 +954,8 @@ class ReservationBulkViewSet(viewsets.ModelViewSet, ReservationCacheMixin):
                 }
             })
             res = reservations[0]
-            url = ''.join([request.is_secure() and 'https' or 'http', get_current_site(request).domain, '/v1/', 'reservation/', str(res.id), '/'])
+            url = ''.join([request.is_secure() and 'https' or 'http', get_current_site(
+                request).domain, '/v1/', 'reservation/', str(res.id), '/'])
             ical_file = build_reservations_ical_file(reservations)
             attachment = ('reservation.ics', ical_file, 'text/calendar')
             res.send_reservation_mail(
@@ -962,7 +965,8 @@ class ReservationBulkViewSet(viewsets.ModelViewSet, ReservationCacheMixin):
                 extra_context=reservation_dates_context
             )
             return JsonResponse(
-                data={ **ReservationSerializer(context={'request': self.request if self.request else request}).to_representation(res) },
+                data={
+                    **ReservationSerializer(context={'request': self.request if self.request else request}).to_representation(res)},
                 status=200)
         except Exception as ex:
             return JsonResponse(
@@ -1035,14 +1039,17 @@ class ReservationViewSet(munigeo_api.GeoModelAPIView, viewsets.ModelViewSet, Res
             return queryset
 
         # normal users can see only their own reservations and reservations that are confirmed, requested or
-        # waiting for payment
+        # waiting for payment. Unit admins and managers can see all reservations of their units.
         filters = Q(state__in=(Reservation.CONFIRMED, Reservation.REQUESTED,
-            Reservation.WAITING_FOR_PAYMENT, Reservation.READY_FOR_PAYMENT,
-            Reservation.WAITING_FOR_CASH_PAYMENT))
+                               Reservation.WAITING_FOR_PAYMENT, Reservation.READY_FOR_PAYMENT,
+                               Reservation.WAITING_FOR_CASH_PAYMENT))
         if user.is_authenticated:
             filters |= Q(user=user)
-        queryset = queryset.filter(filters)
 
+        if is_any_admin(user) or is_any_manager(user):
+            filters |= Q(resource__unit__in=Unit.objects.managed_by(user))
+
+        queryset = queryset.filter(filters)
         queryset = queryset.filter(resource__in=Resource.objects.visible_for(user))
         return queryset
 
@@ -1066,13 +1073,13 @@ class ReservationViewSet(munigeo_api.GeoModelAPIView, viewsets.ModelViewSet, Res
             if order and order.state != Order.CONFIRMED and not resource.can_bypass_manual_confirmation(user):
                 new_state = Reservation.WAITING_FOR_PAYMENT
             elif order and order.state == Order.WAITING and order.payment_method == Order.CASH \
-                and resource.cash_payments_allowed and resource.can_bypass_manual_confirmation(user):
+                    and resource.cash_payments_allowed and resource.can_bypass_manual_confirmation(user):
                 new_state = Reservation.WAITING_FOR_CASH_PAYMENT
             else:
                 new_state = Reservation.CONFIRMED
 
         if new_state == Reservation.CONFIRMED and \
-            order and order.state == Order.WAITING and not resource.can_bypass_manual_confirmation(user):
+                order and order.state == Order.WAITING and not resource.can_bypass_manual_confirmation(user):
             new_state = Reservation.WAITING_FOR_PAYMENT
 
         instance.set_state(new_state, self.request.user)
@@ -1086,7 +1093,7 @@ class ReservationViewSet(munigeo_api.GeoModelAPIView, viewsets.ModelViewSet, Res
 
         # when staff makes an update (can edit paid perm), state should not change to waiting for payment
         if new_state == Reservation.READY_FOR_PAYMENT and \
-            order and order.state == Order.WAITING and not can_edit_paid:
+                order and order.state == Order.WAITING and not can_edit_paid:
             new_state = Reservation.WAITING_FOR_PAYMENT
 
         if new_state == Reservation.CONFIRMED and order and order.state == Order.WAITING:
@@ -1100,7 +1107,7 @@ class ReservationViewSet(munigeo_api.GeoModelAPIView, viewsets.ModelViewSet, Res
         new_instance.set_state(new_state, self.request.user)
 
         if old_instance.state == Reservation.WAITING_FOR_CASH_PAYMENT and \
-            new_state == Reservation.CONFIRMED:
+                new_state == Reservation.CONFIRMED:
             new_instance.get_order().set_state(Order.CONFIRMED, 'Cash payment confirmed.')
 
         # Reservation was modified, don't send modified upon patch.
@@ -1131,6 +1138,7 @@ class ReservationViewSet(munigeo_api.GeoModelAPIView, viewsets.ModelViewSet, Res
         new_instance.send_reservation_modified_mail(action_by_official=is_staff)
         if not is_staff:
             new_instance.notify_staff_about_reservation(NotificationType.RESERVATION_MODIFIED_OFFICIAL)
+
 
 register_view(ReservationViewSet, 'reservation')
 register_view(ReservationBulkViewSet, 'reservation_bulk')

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -192,6 +192,24 @@ def reservations_in_all_states(resource_in_unit, user):
 
 
 @pytest.fixture
+def reservations_in_all_states2(resource_in_unit2, user):
+    all_states = (
+        Reservation.CANCELLED, Reservation.CONFIRMED, Reservation.DENIED, Reservation.REQUESTED,
+        Reservation.WAITING_FOR_PAYMENT, Reservation.WAITING_FOR_CASH_PAYMENT
+    )
+    reservations = dict()
+    for i, state in enumerate(all_states, 1):
+        reservations[state] = Reservation.objects.create(
+            resource=resource_in_unit2,
+            begin='2115-04-0%sT09:00:00+02:00' % i,
+            end='2115-04-0%sT10:00:00+02:00' % i,
+            user=user,
+            state=state
+        )
+    return reservations
+
+
+@pytest.fixture
 def reservation_created_notification():
     with translation.override('en'):
         return NotificationTemplate.objects.create(
@@ -466,6 +484,7 @@ def test_comments_are_only_for_admins(
     response = api_client.get(response.data['url'])
     assert 'comments' not in response.data
 
+
 @pytest.mark.parametrize('user_fixture, expected_status', [
     (None, 401),
     ('user', 400),
@@ -473,7 +492,6 @@ def test_comments_are_only_for_admins(
     ('staff_user', 201),
     ('unit4_manager_user', 201),
 ])
-
 @pytest.mark.django_db
 def test_comments_can_be_created_by_correct_people_when_resource_sets_is_reservable_by_all(
         api_client, list_url, resource_in_unit, resource_in_unit3, reservation_data, user_fixture, expected_status,
@@ -493,7 +511,6 @@ def test_comments_can_be_created_by_correct_people_when_resource_sets_is_reserva
     resource_in_unit.reservation_metadata_set = ReservationMetadataSet.objects.get(name='updated_metadata')
     resource_in_unit.reservable_by_all_staff = True
     resource_in_unit.save()
-
 
     test_comment = 'test comment abc'
     reservation_data.update({
@@ -520,6 +537,7 @@ def test_comments_can_be_created_by_correct_people_when_resource_sets_is_reserva
     if response.status_code == 201:
         assert response.data['comments'] == test_comment
 
+
 @pytest.mark.parametrize('user_fixture, expected_status_post, expected_status_put ', [
     (None, 401, 400),
     ('user', 400, 400),
@@ -527,7 +545,6 @@ def test_comments_can_be_created_by_correct_people_when_resource_sets_is_reserva
     ('staff_user', 201, 200),
     ('unit4_manager_user', 201, 200),
 ])
-
 @pytest.mark.django_db
 def test_comments_can_be_updated_by_correct_people_when_resource_sets_is_reservable_by_all(
         api_client, list_url, resource_in_unit, resource_in_unit3, reservation_data, user_fixture, expected_status_post, expected_status_put,
@@ -579,6 +596,7 @@ def test_comments_can_be_updated_by_correct_people_when_resource_sets_is_reserva
         assert response.status_code == expected_status_put
         if response.status_code == 200:
             assert response.data['comments'] == updated_comment
+
 
 @pytest.mark.django_db
 def test_anon_and_other_users_cannot_see_virtual_event_data(api_client, reservation, user2):
@@ -918,7 +936,6 @@ def test_strong_reservation(api_client, list_url, reservation_data, strong_user,
     assert response.status_code == 403
 
 
-
 @pytest.mark.django_db
 def test_reservation_user_filter(api_client, list_url, reservation, resource_in_unit, user, user2):
     """
@@ -1164,7 +1181,8 @@ def test_staff_event_restrictions(user_api_client, staff_api_client, staff_user,
     assert set(DEFAULT_REQUIRED_RESERVATION_EXTRA_FIELDS) == set(response.data)
 
     # unit manager but reserver_name and event_description missing
-    UnitAuthorization.objects.create(subject=resource_in_unit.unit, level=UnitAuthorizationLevel.manager, authorized=staff_user)
+    UnitAuthorization.objects.create(subject=resource_in_unit.unit,
+                                     level=UnitAuthorizationLevel.manager, authorized=staff_user)
     response = staff_api_client.post(list_url, data=reservation_data)
     assert response.status_code == 400
     assert {'reserver_name', 'event_description'} == set(response.data)
@@ -1185,7 +1203,8 @@ def test_new_staff_event_gets_confirmed(user_api_client, staff_api_client, staff
 
     reservation.delete()
 
-    UnitAuthorization.objects.create(subject=resource_in_unit.unit, level=UnitAuthorizationLevel.manager, authorized=staff_user)
+    UnitAuthorization.objects.create(subject=resource_in_unit.unit,
+                                     level=UnitAuthorizationLevel.manager, authorized=staff_user)
     reservation_data['staff_event'] = True
     reservation_data['reserver_name'] = 'herra huu'
     reservation_data['event_description'] = 'herra huun bileet'
@@ -1256,6 +1275,64 @@ def test_admins_can_see_reservations_in_all_states(
 
 
 @pytest.mark.django_db
+def test_unit_manager_can_see_all_reservations_in_their_unit(
+        resource_in_unit, api_client, staff_user, reservations_in_all_states, list_url):
+    """
+    Tests that unit managers can see reservations made to their resources in all 6 reservation states
+    """
+    UnitAuthorization.objects.create(subject=resource_in_unit.unit,
+                                     level=UnitAuthorizationLevel.manager, authorized=staff_user)
+    api_client.force_authenticate(user=staff_user)
+    response = api_client.get(list_url)
+    assert response.status_code == 200
+    assert response.data['count'] == 6
+
+
+@pytest.mark.django_db
+def test_unit_admin_can_see_all_reservations_in_their_unit(
+        resource_in_unit, api_client, staff_user, reservations_in_all_states, list_url):
+    """
+    Tests that unit admins can see reservations made to their resources in all 6 reservation states
+    """
+    UnitAuthorization.objects.create(subject=resource_in_unit.unit,
+                                     level=UnitAuthorizationLevel.admin, authorized=staff_user)
+    api_client.force_authenticate(user=staff_user)
+    response = api_client.get(list_url)
+    assert response.status_code == 200
+    assert response.data['count'] == 6
+
+
+@pytest.mark.django_db
+def test_unit_manager_cannot_see_all_reservations_not_in_their_unit(
+        resource_in_unit, api_client, staff_user, reservations_in_all_states2, list_url):
+    """
+    Tests that unit managers can only see reservations made to other than their own unit in the
+    4 allowed reservation states
+    """
+    UnitAuthorization.objects.create(subject=resource_in_unit.unit,
+                                     level=UnitAuthorizationLevel.manager, authorized=staff_user)
+    api_client.force_authenticate(user=staff_user)
+    response = api_client.get(list_url)
+    assert response.status_code == 200
+    assert response.data['count'] == 4
+
+
+@pytest.mark.django_db
+def test_unit_admin_cannot_see_all_reservations_not_in_their_unit(
+        resource_in_unit, api_client, staff_user, reservations_in_all_states2, list_url):
+    """
+    Tests that unit admins can only see reservations made to other than their own unit in the
+    4 allowed reservation states
+    """
+    UnitAuthorization.objects.create(subject=resource_in_unit.unit,
+                                     level=UnitAuthorizationLevel.admin, authorized=staff_user)
+    api_client.force_authenticate(user=staff_user)
+    response = api_client.get(list_url)
+    assert response.status_code == 200
+    assert response.data['count'] == 4
+
+
+@pytest.mark.django_db
 def test_reservation_cannot_be_confirmed_without_permission(
         api_client, user_api_client, detail_url, reservation,
         reservation_data, user2):
@@ -1296,7 +1373,7 @@ def test_reservation_patch_has_arrived(api_client, general_admin, detail_url, re
     reservation.save()
     api_client.force_authenticate(user=general_admin)
     response = api_client.patch(detail_url, data={
-        'has_arrived':True
+        'has_arrived': True
     })
     assert response.status_code == 200
     reservation.refresh_from_db()
@@ -1309,7 +1386,7 @@ def test_reservation_patch_fail_has_arrived(api_client, user2, detail_url, reser
     reservation.save()
     api_client.force_authenticate(user=user2)
     response = api_client.patch(detail_url, data={
-        'has_arrived':True
+        'has_arrived': True
     })
     assert response.status_code == 403
     reservation.refresh_from_db()
@@ -1776,10 +1853,11 @@ def test_reservation_mail_images(user_api_client, user, list_url, reservation_da
 @override_settings(RESPA_MAILS_ENABLED=True)
 @pytest.mark.django_db
 def test_reservation_modified_email_by_official(reservation, reservation_data, staff_api_client, staff_user,
-                                    reservation_modified_by_official_notification):
+                                                reservation_modified_by_official_notification):
     reservation.reserver_email_address = 'test@tester.com'
     reservation.save()
-    UnitAuthorization.objects.create(subject=reservation.resource.unit, level=UnitAuthorizationLevel.manager, authorized=staff_user)
+    UnitAuthorization.objects.create(subject=reservation.resource.unit,
+                                     level=UnitAuthorizationLevel.manager, authorized=staff_user)
     reservation_data['preferred_language'] = 'en'
     reservation_data['reserver_name'] = 'new name'
     detail_url = reverse('reservation-detail', kwargs={'pk': reservation.pk})
@@ -1796,10 +1874,11 @@ def test_reservation_modified_email_by_official(reservation, reservation_data, s
 @override_settings(RESPA_MAILS_ENABLED=True)
 @pytest.mark.django_db
 def test_reservation_modified_email_by_official_comment_only(reservation, reservation_data, staff_api_client, staff_user,
-                                    reservation_modified_by_official_notification):
+                                                             reservation_modified_by_official_notification):
     reservation.reserver_email_address = 'test@tester.com'
     reservation.save()
-    UnitAuthorization.objects.create(subject=reservation.resource.unit, level=UnitAuthorizationLevel.manager, authorized=staff_user)
+    UnitAuthorization.objects.create(subject=reservation.resource.unit,
+                                     level=UnitAuthorizationLevel.manager, authorized=staff_user)
     reservation_data['preferred_language'] = 'en'
     reservation_data['comments'] = 'test comment'
     reservation_data['begin'] = reservation.begin
@@ -1936,7 +2015,6 @@ def test_access_code_visibility(
 @pytest.mark.django_db
 def test_reservation_created_with_access_code_mail(user_api_client, user, resource_in_unit, list_url, reservation_data):
     reservation_data['preferred_language'] = 'en'
-
 
     # The mail should not be sent if access code type is none
     response = user_api_client.post(list_url, data=reservation_data)
@@ -2351,7 +2429,8 @@ def test_manager_can_make_staff_reservation(
     reservation_data['staff_event'] = True
     reservation_data['reserver_name'] = 'herra huu'
     reservation_data['event_description'] = 'herra huun bileet'
-    UnitAuthorization.objects.create(subject=resource_in_unit.unit, level=UnitAuthorizationLevel.manager, authorized=staff_user)
+    UnitAuthorization.objects.create(subject=resource_in_unit.unit,
+                                     level=UnitAuthorizationLevel.manager, authorized=staff_user)
     response = staff_api_client.post(list_url, data=reservation_data)
     assert response.status_code == 201, "Request failed with: %s" % (str(response.content, 'utf8'))
     assert response.data.get('staff_event', False) is True
@@ -2373,8 +2452,6 @@ def test_resource_filter(resource_in_unit, resource_in_unit2, other_resource, re
     response = api_client.get(list_url + '?resource={},{}'.format(resource_in_unit.id, resource_in_unit2.id))
     assert response.status_code == 200
     assert_response_objects(response, (reservation, reservation2))
-
-
 
 
 @pytest.mark.django_db
@@ -2587,6 +2664,7 @@ def test_viewer_can_view_reservation_user(api_client, reservation, unit_viewer_u
     response = api_client.get(detail_url)
     assert response.status_code == 200
     assert response.data['user']['email'] == user.email
+
 
 @pytest.mark.django_db
 def test_viewer_can_modify_reservations(resource_in_unit, resource_in_unit2, api_client, unit_viewer_user, reservation_data, detail_url):
@@ -2976,8 +3054,8 @@ def test_disallow_overlapping_reservations(resource_in_unit, resource_in_unit2, 
 
 @pytest.mark.django_db
 def test_reservation_can_be_made_to_unit_with_overlap_restriction_when_no_overlap(
-        api_client, reservation_data, user, list_url, resource_in_unit4_1
-    ):
+    api_client, reservation_data, user, list_url, resource_in_unit4_1
+):
     """
     Tests that a reservation can be made to a resource in unit with overlap restriction
     when there is no overlap
@@ -2998,9 +3076,9 @@ def test_reservation_can_be_made_to_unit_with_overlap_restriction_when_no_overla
 ])
 @pytest.mark.django_db
 def test_reservations_made_to_unit_with_overlap_restriction_when_overlapping(
-        resource, is_staff, expected, api_client, reservation_data,
-        user, unit4_manager_user, list_url, resource_in_unit4_1, resource_in_unit4_2, reservation4
-    ):
+    resource, is_staff, expected, api_client, reservation_data,
+    user, unit4_manager_user, list_url, resource_in_unit4_1, resource_in_unit4_2, reservation4
+):
     """
     Tests that reservations are handled correctly to resources in units with overlap
     restrictions
@@ -3019,8 +3097,8 @@ def test_reservations_made_to_unit_with_overlap_restriction_when_overlapping(
 
 @pytest.mark.django_db
 def test_reservation_can_be_updated_in_unit_with_overlap_restriction_when_no_overlap(
-        api_client, reservation_data, user, resource_in_unit4_1, reservation4
-    ):
+    api_client, reservation_data, user, resource_in_unit4_1, reservation4
+):
     """
     Tests that a reservation can be updated to a resource in unit with overlap restriction
     when there is no overlap
@@ -3040,8 +3118,8 @@ def test_reservation_can_be_updated_in_unit_with_overlap_restriction_when_no_ove
 
 @pytest.mark.django_db
 def test_reservation_can_be_made_to_unit_with_per_user_overlap_restriction_when_no_overlap(
-        api_client, reservation_data, user, list_url, resource_in_unit4_1
-    ):
+    api_client, reservation_data, user, list_url, resource_in_unit4_1
+):
     """
     Tests that a reservation can be made to a resource in unit with per user overlap restriction
     when there is no overlap
@@ -3062,9 +3140,9 @@ def test_reservation_can_be_made_to_unit_with_per_user_overlap_restriction_when_
 ])
 @pytest.mark.django_db
 def test_reservations_made_to_unit_with_per_user_overlap_restriction(
-        api_client, reservation_data, user, user2, list_url, test_unit4, resource_in_unit4_2,
-        reservation4, same_user, expected
-    ):
+    api_client, reservation_data, user, user2, list_url, test_unit4, resource_in_unit4_2,
+    reservation4, same_user, expected
+):
     """
     Tests that reservations are handled correctly to a resource in unit with per user overlap restriction
     when same or other user has made a reservation to another resource in the same unit with overlapping time
@@ -3104,8 +3182,8 @@ def test_reservation_can_be_made_to_unit_with_per_user_overlap_restriction_and_a
 
 @pytest.mark.django_db
 def test_reservation_can_be_updated_in_unit_with_per_user_overlap_restriction_when_no_overlap(
-        api_client, reservation_data, user, resource_in_unit4_1, reservation4, test_unit4
-    ):
+    api_client, reservation_data, user, resource_in_unit4_1, reservation4, test_unit4
+):
     """
     Tests that a reservation can be updated to a resource in unit with per user overlap restriction
     when there is no overlap
@@ -3127,8 +3205,8 @@ def test_reservation_can_be_updated_in_unit_with_per_user_overlap_restriction_wh
 
 @pytest.mark.django_db
 def test_reservation_cannot_be_updated_in_unit_with_per_user_overlap_restriction_when_overlapping(
-        api_client, reservation_data, user, resource_in_unit4_1, reservation4, reservation5, test_unit4
-    ):
+    api_client, reservation_data, user, resource_in_unit4_1, reservation4, reservation5, test_unit4
+):
     """
     Tests that a reservation cannot be updated to a resource in unit with per user overlap restriction
     when there is overlap
@@ -3165,9 +3243,9 @@ def test_reservation_cannot_be_updated_in_unit_with_per_user_overlap_restriction
 ])
 @pytest.mark.django_db
 def test_reservations_made_to_unit_with_overlap_restriction_with_different_times(
-        begin, end, expected, api_client, reservation_data, user, list_url,
-        resource_in_unit4_1, resource_in_unit4_2, reservation4, reservation5
-    ):
+    begin, end, expected, api_client, reservation_data, user, list_url,
+    resource_in_unit4_1, resource_in_unit4_2, reservation4, reservation5
+):
     """
     Tests that reservations are handled correctly to resources in units with overlap
     restrictions when reserving different length reservations and with different overlaps


### PR DESCRIPTION
# Unit managers and admins can see denied and cancelled reservations

Unit managers and admins can now see all reservations made to their resources, including denied and cancelled reservations

[Related Trello card](https://trello.com/c/V5OBURJS)

-----------------------------------------------------------------------------------------------
## Breakdown:

### Reservation visibility for unit managers and admins
 1. resources/api/reservation.py
     * allowed unit managers and admins to see all reservations in all states including denied and cancelled reservations