### PR TITLE
Fixed per period product quantity pricing issue

### DIFF
--- a/payments/api/base.py
+++ b/payments/api/base.py
@@ -73,6 +73,10 @@ class OrderLineSerializer(serializers.ModelSerializer):
         for x in detailed_prices:
             temp = detailed_prices[x]['tax_total'] + detailed_prices[x]['taxfree_price_total']
             price += temp
+
+        # quantity needs to be handled separately for per period products
+        if obj.product.price_type != Product.PRICE_FIXED:
+            price *= obj.quantity
         return '{:.2f}'.format(price)
 
     def to_representation(self, instance):

--- a/payments/models.py
+++ b/payments/models.py
@@ -609,6 +609,9 @@ class Product(models.Model):
                         pretax=self.get_pretax_price_context(price, rounded=False),
                         taxfree_price=self.price_tax_free
                     )
+                    if quantity > 1:
+                        # quantity is only defined/>1 if there are multiples of the same product
+                        detailed_pricing['default']['quantity'] = quantity
                 slot_begin += check_interval
 
             detailed_pricing = finalize_price_data(detailed_pricing, self.price_type, self.price_period)

--- a/payments/tests/test_order_api.py
+++ b/payments/tests/test_order_api.py
@@ -236,3 +236,100 @@ def test_order_price_check_with_fixed_price_product_returns_correct_price(begin,
     assert response.status_code == 200
     assert len(response.data['order_lines']) == 2
     assert response.data['price'] == price_result
+
+
+@pytest.mark.parametrize('begin, end, customer_group, price', (
+    (datetime(2022, 3, 1, 10, 0), datetime(2022, 3, 1, 12, 0), None, 20.00),
+    (datetime(2022, 3, 1, 10, 0), datetime(2022, 3, 1, 12, 0), 'cg-adults-1', 16.00),
+    (datetime(2022, 3, 1, 10, 0), datetime(2022, 3, 1, 12, 0), 'cg-children-1', 22.00),
+    (datetime(2022, 3, 1, 10, 0), datetime(2022, 3, 1, 12, 0), 'cg-elders-1', 12.00),
+    (datetime(2022, 3, 1, 10, 0), datetime(2022, 3, 1, 12, 0), 'cg-companies-1', 20.00),
+    (datetime(2022, 3, 1, 14, 0), datetime(2022, 3, 1, 16, 0), None, 30.00),
+    (datetime(2022, 3, 1, 14, 0), datetime(2022, 3, 1, 16, 0), 'cg-adults-1', 24.00),
+    (datetime(2022, 3, 1, 14, 0), datetime(2022, 3, 1, 16, 0), 'cg-children-1', 22.00),
+    (datetime(2022, 3, 1, 14, 0), datetime(2022, 3, 1, 16, 0), 'cg-elders-1', 30.00),
+    (datetime(2022, 3, 1, 14, 0), datetime(2022, 3, 1, 16, 0), 'cg-companies-1', 30.00),
+    (datetime(2022, 3, 1, 11, 30), datetime(2022, 3, 1, 12, 30), None, 12.50),
+    (datetime(2022, 3, 1, 11, 30), datetime(2022, 3, 1, 12, 30), 'cg-adults-1', 10.00),
+    (datetime(2022, 3, 1, 11, 30), datetime(2022, 3, 1, 12, 30), 'cg-children-1', 11.00),
+    (datetime(2022, 3, 1, 11, 30), datetime(2022, 3, 1, 12, 30), 'cg-elders-1', 10.50),
+    (datetime(2022, 3, 1, 11, 30), datetime(2022, 3, 1, 12, 30), 'cg-companies-1', 12.50)
+))
+def test_order_price_check_per_period_price_product_rounded_price_is_correct(begin, end, customer_group, price,
+    product_with_pcgs_and_time_slot_prices, user_api_client, product_with_all_named_customer_groups):
+    '''
+    Test the check price endpoint returns rough correct orderline rounded price for a product containing
+    a time slot and product customer groups.
+    '''
+    for quantity in range(3):
+        price_check_data = {
+            "order_lines": [
+                {
+                    "product": product_with_pcgs_and_time_slot_prices.product_id,
+                    "quantity": quantity
+                },
+                {
+                    "product": product_with_all_named_customer_groups.product_id,
+                    "quantity": 0
+                },
+            ],
+            "begin": str(begin),
+            "end": str(end),
+        }
+
+        if customer_group:
+            price_check_data['customer_group'] = customer_group
+        response = user_api_client.post(CHECK_PRICE_URL, price_check_data)
+        assert response.status_code == 200
+        orderlines = response.data['order_lines']
+        assert len(orderlines) == 2
+        assert round(float(orderlines[0]['rounded_price'])) == round(price*quantity)
+
+
+@pytest.mark.parametrize('begin, end, customer_group, price', (
+    (datetime(2022, 3, 1, 7, 0), datetime(2022, 3, 1, 8, 0), None, 50.25),
+    (datetime(2022, 3, 1, 7, 0), datetime(2022, 3, 1, 11, 0), None, 50.25),
+    (datetime(2022, 3, 1, 10, 0), datetime(2022, 3, 1, 11, 0), None, 10.00),
+    (datetime(2022, 3, 1, 10, 0), datetime(2022, 3, 1, 12, 0), None, 10.00),
+    (datetime(2022, 3, 1, 12, 0), datetime(2022, 3, 1, 13, 0), None, 12.00),
+    (datetime(2022, 3, 1, 12, 0), datetime(2022, 3, 1, 15, 30), None, 11.50),
+    (datetime(2022, 3, 1, 14, 0), datetime(2022, 3, 1, 16, 0), None, 14.00),
+    (datetime(2022, 3, 1, 10, 0), datetime(2022, 3, 1, 16, 0), 'cg-adults-1', 50.25),
+    (datetime(2022, 3, 1, 14, 0), datetime(2022, 3, 1, 15, 0), 'cg-adults-1', 8.00),
+    (datetime(2022, 3, 1, 14, 0), datetime(2022, 3, 1, 16, 0), 'cg-adults-1', 8.00),
+    (datetime(2022, 3, 1, 15, 0), datetime(2022, 3, 1, 16, 0), 'cg-adults-1', 7.00),
+    (datetime(2022, 3, 1, 7, 0), datetime(2022, 3, 1, 8, 0), 'cg-children-1', 6.50),
+    (datetime(2022, 3, 1, 14, 0), datetime(2022, 3, 1, 16, 0), 'cg-children-1', 6.50),
+    (datetime(2022, 3, 1, 7, 0), datetime(2022, 3, 1, 8, 0), 'cg-elders-1', 50.25),
+    (datetime(2022, 3, 1, 10, 0), datetime(2022, 3, 1, 11, 0), 'cg-elders-1', 10.00),
+    (datetime(2022, 3, 1, 14, 0), datetime(2022, 3, 1, 16, 0), 'cg-elders-1', 14.00),
+))
+def test_order_price_check_fixed_price_product_rounded_price_is_correct(begin, end, customer_group, price,
+    product_with_fixed_price_type_and_time_slots, user_api_client, product_with_all_named_customer_groups):
+    '''
+    Test the check price endpoint returns rough correct orderline rounded price for a product containing
+    time slots, product customer groups and fixed pricing.
+    '''
+    for quantity in range(3):
+        price_check_data = {
+            "order_lines": [
+                {
+                    "product": product_with_fixed_price_type_and_time_slots.product_id,
+                    "quantity": quantity
+                },
+                {
+                    "product": product_with_all_named_customer_groups.product_id,
+                    "quantity": 0
+                },
+            ],
+            "begin": str(begin),
+            "end": str(end),
+        }
+
+        if customer_group:
+            price_check_data['customer_group'] = customer_group
+        response = user_api_client.post(CHECK_PRICE_URL, price_check_data)
+        assert response.status_code == 200
+        orderlines = response.data['order_lines']
+        assert len(orderlines) == 2
+        assert round(float(orderlines[0]['rounded_price'])) == round(price*quantity)

--- a/payments/tests/test_product.py
+++ b/payments/tests/test_product.py
@@ -127,3 +127,35 @@ def test_get_pretax_price_for_reservation_success(product_1, two_hour_reservatio
     not_rounded = product_1.get_pretax_price_for_reservation(two_hour_reservation, rounded=False)
     assert rounded == Decimal('20.66')
     assert not_rounded.quantize(Decimal('0.00001')) == Decimal('20.66129')
+
+
+def test_get_detailed_price_for_time_range_per_period_timeslots_quantity(product_with_pcgs_and_time_slot_prices):
+    """Test quantity is added correctly to detailed pricing with per period products with timeslots"""
+    begin = datetime.datetime(2119, 5, 5, 10, 0, 0, tzinfo=UTC)
+    end = datetime.datetime(2119, 5, 5, 12, 0, 0, tzinfo=UTC)
+
+    result = product_with_pcgs_and_time_slot_prices.get_detailed_price_for_time_range(begin, end, quantity=0)
+    assert 'quantity' not in result['default']
+
+    result = product_with_pcgs_and_time_slot_prices.get_detailed_price_for_time_range(begin, end, quantity=1)
+    assert 'quantity' not in result['default']
+
+    result = product_with_pcgs_and_time_slot_prices.get_detailed_price_for_time_range(begin, end, quantity=2)
+    assert 'quantity' in result['default']
+    assert result['default']['quantity'] == 2
+
+
+def test_get_detailed_price_for_time_range_per_period_no_timeslots_quantity(product_with_no_price_product_cg):
+    """Test quantity is added correctly to detailed pricing with per period products without timeslots"""
+    begin = datetime.datetime(2119, 5, 5, 10, 0, 0, tzinfo=UTC)
+    end = datetime.datetime(2119, 5, 5, 12, 0, 0, tzinfo=UTC)
+
+    result = product_with_no_price_product_cg.get_detailed_price_for_time_range(begin, end, quantity=0)
+    assert 'quantity' not in result['default']
+
+    result = product_with_no_price_product_cg.get_detailed_price_for_time_range(begin, end, quantity=1)
+    assert 'quantity' not in result['default']
+
+    result = product_with_no_price_product_cg.get_detailed_price_for_time_range(begin, end, quantity=2)
+    assert 'quantity' in result['default']
+    assert result['default']['quantity'] == 2


### PR DESCRIPTION
# Fixed per period product quantity pricing issue

Changes:
- quantity is now added when quantity is over 1 to detailed pricing for per period products without time slot pricing
- api orderline `rounded_price` returns price*quantity for per period products instead of always returning pricing of one product

[Related Trello card](https://trello.com/c/WbDXGUuU)

-----------------------------------------------------------------------------------------------
## Breakdown:

#### per period priced product quantity issue
 1. payments/api/base.py
     * rounded price returns price*quantity for per period products instead of always returning a single product's price
   
 2. payments/models.py
     * quantity is added to detailed pricing for per period products that do not have time slot prices