### PR TITLE
Fixed admin reservation metadata empty set issue

### DIFF
--- a/resources/admin/__init__.py
+++ b/resources/admin/__init__.py
@@ -380,17 +380,21 @@ class TermsOfUseAdmin(PopulateCreatedAndModifiedMixin, CommonExcludeMixin, Trans
 
 class ReservationMetadataSetForm(forms.ModelForm):
     supported_fields = forms.ModelMultipleChoiceField(
-        ReservationMetadataField.objects.all(), widget=FilteredSelectMultiple(_('Supported fields'), False))
+        ReservationMetadataField.objects.all(),
+        widget=FilteredSelectMultiple(_('Supported fields'), False),
+        required=False)
     required_fields = forms.ModelMultipleChoiceField(
-        ReservationMetadataField.objects.all(), widget=FilteredSelectMultiple(_('Required fields'), False))
+        ReservationMetadataField.objects.all(),
+        widget=FilteredSelectMultiple(_('Required fields'), False),
+        required=False)
 
     class Meta:
         model = ReservationMetadataSet
         exclude = CommonExcludeMixin.exclude + ('id',)
 
     def clean(self):
-        supported = set(self.cleaned_data.get('supported_fields'))
-        required = set(self.cleaned_data.get('required_fields'))
+        supported = set(self.cleaned_data.get('supported_fields', []))
+        required = set(self.cleaned_data.get('required_fields', []))
         if not required.issubset(supported):
             raise ValidationError(_('Required fields must be a subset of supported fields'))
         return self.cleaned_data


### PR DESCRIPTION
# Fixed admin reservation metadata empty set issue

Changes:
- set supported and required fields to not be required
- fixed empty field sets causing an error

-----------------------------------------------------------------------------------------------
## Breakdown:

### admin reservation metadata empty set issue
 1. resources/admin/__init__.py 
     * supported and required fields are no longer required
     * handled none type error when either field set was empty