### PR TITLE
Fixed RA user can approve reservation issues

### DIFF
--- a/respa_admin/forms.py
+++ b/respa_admin/forms.py
@@ -733,12 +733,13 @@ class UnitAuthorizationForm(forms.ModelForm):
             user_has_unit_group_auth = self.request.user.unit_group_authorizations.to_unit(unit).admin_level().exists()
             can_approve_initial_value = permission_checker.has_perm(
                 "unit:can_approve_reservation", self.instance.subject
-            ) or self.instance.subject.is_manager(self.instance.authorized)
+            )
             if not user_has_unit_auth and not user_has_unit_group_auth:
                 self.fields['subject'].disabled = True
                 self.fields['level'].disabled = True
                 self.fields['can_approve_reservation'].disabled = True
                 self.is_disabled = True
+            self.fields['can_approve_reservation'].widget.attrs['data-unit-id'] = f'{unit.id}'
         self.fields['can_approve_reservation'].initial = can_approve_initial_value
 
     def clean(self):
@@ -750,6 +751,8 @@ class UnitAuthorizationForm(forms.ModelForm):
             if not user_has_unit_auth and not user_has_unit_group_auth:
                 self.add_error('subject', _('You can\'t add, change or delete permissions to unit you are not admin of'))
                 self.cleaned_data[DELETION_FIELD_NAME] = False
+            if self.cleaned_data[DELETION_FIELD_NAME]:
+                self.cleaned_data['can_approve_reservation'] = False
         return cleaned_data
 
     class Meta:

--- a/respa_admin/static_src/js/userForm.js
+++ b/respa_admin/static_src/js/userForm.js
@@ -103,9 +103,25 @@ function updateAllPermissionMgmtFormIndices() {
   }
 }
 
+function canApproveReservationsListener() {
+  $('[id*="-can_approve_reservation"]').on('click', handleCanApproveReservationsChange);
+}
+
+function handleCanApproveReservationsChange(event) {
+  const unitId = $(this).closest('.custom-checkbox').attr('data-unit-id')
+  const value = event.currentTarget.checked
+  if (unitId) {
+    const $inputs = $('[data-unit-id="' + unitId + '"]');
+    $inputs.prop('checked', value)
+  }
+
+  initializeUserForm();
+}
+
 export function initializeUserFormEventHandlers() {
   enableRemovePermission();
   enableAddNewPermission();
   setEmptyPermissionItem();
   isStaffCheckboxListener();
+  canApproveReservationsListener();
 }

--- a/respa_admin/templates/respa_admin/resources/_unit_user_list.html
+++ b/respa_admin/templates/respa_admin/resources/_unit_user_list.html
@@ -40,7 +40,7 @@
                     {% if unit_auths|length > 6 %}style="min-height: 690px;"{% endif %}>
                 {% for authorization in unit_auths %}
                 {% with authorization.authorized as unit_user %}
-                {% user_has_permission unit_user 'can_approve_reservation' unit as user_can_approve %}
+                {% user_has_permission unit_user 'unit:can_approve_reservation' unit as user_can_approve %}
                 <div class="row panel management-list list-item" data-paginator-item="true">
                     <div class="col-md-2">
                         <span>{{ unit_user.first_name }} {{ unit_user.last_name }}</span>

--- a/respa_admin/templatetags/templatetags.py
+++ b/respa_admin/templatetags/templatetags.py
@@ -41,7 +41,7 @@ def get_value_from_dict(dict_data, key):
 
 @register.simple_tag
 def user_has_permission(user, permission, obj):
-    return user.has_perm(permission, obj) or obj.is_manager(user)
+    return user.has_perm(permission, obj)
 
 
 @register.filter


### PR DESCRIPTION
# Fix to RA user management "can approve reservation" permission issues

Changes:
- it is no longer assumed user has `can_approve_reservation` permission when they have unit manager permissions
- when all unit's permissions get deleted, `can_approve_reservation` is also removed from user if the user had it
- when clicking to toggle `can_approve_reservation`, all check boxes belonging to the same unit, will change to the same value

[Related Trello card](https://trello.com/c/3z5o8xWM)

-----------------------------------------------------------------------------------------------
## Breakdown:

### RA user can approve reservation issues
 1. respa_admin/forms.py
     * no longer assume manager has/gets `can_approve_reservation`
     * when form gets delete command set `can_approve_reservation` to false
   
 2. respa_admin/static_src/js/userForm.js
     * added function to handle can approve reservation toggling to affect all check boxes of the same unit
    
 3. respa_admin/templatetags/templatetags.py
     * no longer assume manager has/gets `can_approve_reservation`