### PR TITLE
Added maintenance mode status to announcements api

### DIFF
--- a/maintenance/api/announcements.py
+++ b/maintenance/api/announcements.py
@@ -1,13 +1,26 @@
-from rest_framework import viewsets
+from django.utils import timezone
+from rest_framework import viewsets, serializers
 from resources.api.base import TranslatedModelSerializer, register_view
 from maintenance.models import MaintenanceMessage
 
 
 
 class MaintenanceMessageSerializer(TranslatedModelSerializer):
+    is_maintenance_mode_on = serializers.SerializerMethodField()
+
     class Meta:
         model = MaintenanceMessage
-        fields = ('message', )
+        fields = ('message', 'is_maintenance_mode_on')
+
+    def get_is_maintenance_mode_on(self, obj):
+        maintenance_modes = obj.maintenancemode_set.all()
+        now = timezone.now()
+
+        for maintenance_mode in maintenance_modes:
+            if maintenance_mode.start <= now <= maintenance_mode.end:
+                return True
+
+        return False
 
 
 

--- a/resources/tests/conftest.py
+++ b/resources/tests/conftest.py
@@ -587,9 +587,10 @@ def maintenance_message():
     )
 
 @pytest.fixture
-def maintenance_mode():
+def maintenance_mode(maintenance_message):
     return MaintenanceMode.objects.create(
-        start=timezone.now(), end=timezone.now() + datetime.timedelta(minutes=20)
+        start=timezone.now(), end=timezone.now() + datetime.timedelta(minutes=20),
+        maintenance_message=maintenance_message
     )
 
 @pytest.mark.django_db

--- a/resources/tests/test_maintenance_message.py
+++ b/resources/tests/test_maintenance_message.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
-import datetime 
+import datetime
 from django.utils import timezone
 from django.urls import reverse
 
@@ -25,3 +25,24 @@ def test_maintenance_message(client, maintenance_message):
     results = response.data['results']
     assert len(results) == 0
 
+
+@pytest.mark.django_db
+def test_maintenance_message_is_maintenance_mode_on_when_on(client, maintenance_message, maintenance_mode):
+    response = client.get(LIST_URL, HTTP_ACCEPT='text/html')
+    assert response.status_code == 200
+    results = response.data['results']
+    assert len(results) == 1
+    message = results[0]
+    assert message != None
+    assert message['is_maintenance_mode_on'] == True
+
+
+@pytest.mark.django_db
+def test_maintenance_message_is_maintenance_mode_on_when_off(client, maintenance_message):
+    response = client.get(LIST_URL, HTTP_ACCEPT='text/html')
+    assert response.status_code == 200
+    results = response.data['results']
+    assert len(results) == 1
+    message = results[0]
+    assert message != None
+    assert message['is_maintenance_mode_on'] == False


### PR DESCRIPTION
# Maintenance mode status to announcements API

Announcements API will now include `is_maintenance_mode_on` which tells whether maintenance is currently on or not.

[Related Trello card](https://trello.com/c/NNdTspPH)

-----------------------------------------------------------------------------------------------
## Breakdown:

### maintenance mode status api
 1. maintenance/api/announcements.py
     * added `is_maintenance_mode_on` status to announcements