### PR TITLE
Improved resource staff email list help texts

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1356,7 +1356,7 @@ msgstr ""
 
 #: resources/models/resource.py:187
 msgid "E-mail addresses for client correspondence"
-msgstr ""
+msgstr "Email addresses for receiving notifications of customer reservations"
 
 #: resources/models/resource.py:189
 msgid "Authentication"
@@ -2010,7 +2010,7 @@ msgstr ""
 
 #: respa_admin/templates/respa_admin/resources/form/_booking.html:41
 msgid "A notification will be sent when a space is booked."
-msgstr ""
+msgstr "Notifications are sent regarding customer-made reservations, including their confirmations, changes, and cancellations."
 
 #: respa_admin/templates/respa_admin/resources/form/_equipment.html:8
 msgid "Choose from the list below"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1440,7 +1440,7 @@ msgid "E-mail notifications"
 msgstr "Sähköposti-ilmoitukset"
 
 msgid "A notification will be sent when a space is booked."
-msgstr "Ilmoitus lähetetään, kun tilaa varataan."
+msgstr "Ilmoituksia lähetetään asiakkaiden tekemistä varauksista sekä niiden vahvistuksista, muutoksista ja peruutuksista."
 
 msgid "Extra questions for reservation"
 msgstr "Varauksen lisäkysymykset"
@@ -1701,7 +1701,7 @@ msgid "Reservation created official"
 msgstr "Varaus luotu virkailija"
 
 msgid "E-mail addresses for client correspondence"
-msgstr "Sähköpostiosoitteet asiakasvarausten muutoksille"
+msgstr "Sähköpostiosoitteet ilmoitusten vastaanottamiseen asiakasvarauksista"
 
 msgid "Municipalitys"
 msgstr "Kunnat"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -985,6 +985,9 @@ msgstr "Syften"
 msgid "Need manual confirmation"
 msgstr "Kräver manuell bekräftelse"
 
+msgid "E-mail addresses for client correspondence"
+msgstr "E-postadresser för att ta emot meddelanden om kundreservationer"
+
 msgid "Authentication"
 msgstr "Autentisering"
 
@@ -1439,7 +1442,7 @@ msgid "E-mail notifications"
 msgstr "E-post notifikationer"
 
 msgid "A notification will be sent when a space is booked."
-msgstr "Ett meddelande kommer att skickas då ett utrymme har bokats."
+msgstr "Meddelanden skickas angående kundbokningar, inklusive deras bekräftelser, ändringar och avbokningar."
 
 msgid "Extra questions for reservation"
 msgstr "Extra frågor för bokning"


### PR DESCRIPTION
# Improved resource staff email list help texts

Changed RA's resource form's staff email notification list's related help texts to be more descriptive.

[Related Trello card](https://trello.com/c/OZWVMxAv)