### PR TITLE
Add takes_place_virtually and virtual_address to notification context

### DIFF
--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -514,7 +514,8 @@ class Reservation(ModifiableModel):
                 'require_workstation': self.require_workstation,
                 'private_event': self.private_event,
                 'extra_question': self.reservation_extra_questions,
-                'home_municipality_id': reserver_home_municipality
+                'home_municipality_id': reserver_home_municipality,
+                'takes_place_virtually': self.takes_place_virtually
             }
             directly_included_fields = (
                 'number_of_participants',
@@ -543,6 +544,9 @@ class Reservation(ModifiableModel):
 
             if self.user and self.user.is_staff:
                 context['staff_name'] = self.user.get_display_name()
+            
+            if self.virtual_address:
+                context['virtual_address'] = self.virtual_address
 
             # Comments should only be added to notifications that are sent to staff.
             if notification_type in [NotificationType.RESERVATION_CREATED_OFFICIAL] and self.comments:

--- a/resources/tests/test_reservation.py
+++ b/resources/tests/test_reservation.py
@@ -190,10 +190,37 @@ def test_admin_may_bypass_min_period(resource_with_opening_hours, user):
 
 @pytest.mark.django_db
 def test_reservation_home_municipality_field_str():
-        home_municipality_field = ReservationHomeMunicipalityField.objects.create(name='test municipality')
-        assert str(home_municipality_field) == 'test municipality'
+    home_municipality_field = ReservationHomeMunicipalityField.objects.create(name='test municipality')
+    assert str(home_municipality_field) == 'test municipality'
 
 @pytest.mark.django_db
 def test_reservation_home_municipality_set_str():
-        home_municipality_set = ReservationHomeMunicipalitySet.objects.create(name='test municipality set')
-        assert str(home_municipality_set) == 'test municipality set'
+    home_municipality_set = ReservationHomeMunicipalitySet.objects.create(name='test municipality set')
+    assert str(home_municipality_set) == 'test municipality set'
+
+
+
+@pytest.mark.parametrize('virtual_address', (
+    None,
+    'jokin://linkki/jonnekkin'
+))
+@pytest.mark.django_db
+def test_reservation_notification_template_takes_place_virtually(resource_in_unit, virtual_address):
+
+    tz = timezone.get_current_timezone()
+    begin = tz.localize(datetime.datetime(2115, 6, 1, 8, 0, 0))
+    end = begin + datetime.timedelta(hours=0, minutes=30)
+
+    reservation = Reservation(
+        resource=resource_in_unit,
+        takes_place_virtually=True,
+        virtual_address=virtual_address,
+        begin=begin,
+        end=end
+    )
+    context = reservation.get_notification_context('fi')
+    assert 'takes_place_virtually' in context
+    if virtual_address:
+        assert 'virtual_address' in context
+    else:
+        assert 'virtual_address' not in context

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -3281,8 +3281,6 @@ def test_reservation_reminder_create(
     resource_with_reservation_reminders):
     api_client.force_authenticate(user=user)
     reservation_data['resource'] = resource_with_reservation_reminders.pk
-    reservation_data['begin'] = '2115-04-04T09:00:00+02:00'
-    reservation_data['end'] = '2115-04-04T10:00:00+02:00'
     reservation_data['reserver_name'] = 'Nordea Demo'
     reservation_data['reserver_email_address'] = 'jey@example.com'
     reservation_data['reserver_phone_number'] = '+358404040404'


### PR DESCRIPTION
# Add takes_place_virtually and virtual_address to notification context

## Adds takes_place_virtually and virtual_address to notification context

### [Trello](https://trello.com/c/tbGq4gOE)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Notification context
 1. resources/models/reservation.py 
     * Add reservation field 'takes_place_virtually' to notification context
     * Add reservation field 'virtual_address' to notification context if it exists
   
 2. resources/tests/test_reservation.py
     * Create test for notification context
    