### PR TITLE
Don't send notification on blocked reservation type

### DIFF
--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -756,6 +756,9 @@ class Reservation(ModifiableModel):
                               user=None, attachments=None,
                               staff_email=None,
                               extra_context={}, is_reminder = False):
+        if self.type == Reservation.TYPE_BLOCKED:
+            return
+
         notification_template = self.get_notification_template(notification_type)
         if self.user and not user: # If user isn't given use self.user.
             user = self.user


### PR DESCRIPTION
### Don't send notification on blocked reservation type

[Trello card](https://trello.com/c/deZJlJHD)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Reservations
 1. resources/models/reservation.py 
     * Skip notifications if reservation.type == blocked
   