### PR TITLE
Changed reservable before & after rules for online payments

### DIFF
--- a/resources/models/utils.py
+++ b/resources/models/utils.py
@@ -206,7 +206,7 @@ def generate_reservation_xlsx(reservations, **kwargs):
             else:
                 worksheet.write(row_cursor, col, title, title_format)
             worksheet.set_column(col, col, header[1])
-            
+
         row_cursor += 1
         header_format = workbook.add_format({'bold': True})
         for column, header in enumerate(headers):
@@ -761,5 +761,20 @@ def is_reservation_metadata_or_times_different(old_reservation, new_reservation)
 
     if old_reservation.end != new_reservation.end or old_reservation.begin != new_reservation.begin:
         return True
+
+    return False
+
+
+def has_reservation_data_changed(data, instance) -> bool:
+    """
+    Returns True when given data has changes compared to reservation instance
+    and False when not.
+    """
+    if instance == None:
+        return False
+
+    for field, value in data.items():
+        if getattr(instance, field) != value:
+            return True
 
     return False

--- a/resources/tests/test_utils.py
+++ b/resources/tests/test_utils.py
@@ -3,7 +3,7 @@ import pytest
 from django.conf import settings
 from django.test.utils import override_settings
 from resources.models.utils import (
-    get_payment_requested_waiting_time, is_reservation_metadata_or_times_different, format_dt_range_alt
+    get_payment_requested_waiting_time, has_reservation_data_changed, is_reservation_metadata_or_times_different, format_dt_range_alt
 )
 from resources.models import Reservation, Resource, Unit
 from payments.models import Product, Order
@@ -289,3 +289,31 @@ def test_format_dt_range_alt_different_day(reservation_basic):
     return_value = format_dt_range_alt('en', begin, end)
     expected_value = '2.2.2022 12:00 – 3.2.2022 14:00'
     assert return_value == expected_value
+
+
+@pytest.mark.django_db
+def test_has_reservation_data_changed_no_changes(reservation_basic):
+    data = {'reserver_name': reservation_basic.reserver_name}
+    result = has_reservation_data_changed(data, reservation_basic)
+    assert result is False
+
+
+@pytest.mark.django_db
+def test_has_reservation_data_changed_changes(reservation_basic):
+    data = {'reserver_name': 'changed name'}
+    result = has_reservation_data_changed(data, reservation_basic)
+    assert result is True
+
+
+@pytest.mark.django_db
+def test_has_reservation_data_changed_no_instance():
+    data = {'reserver_name': 'changed name'}
+    result = has_reservation_data_changed(data, None)
+    assert result is False
+
+
+@pytest.mark.django_db
+def test_has_reservation_data_changed_empty_data(reservation_basic):
+    data = {}
+    result = has_reservation_data_changed(data, reservation_basic)
+    assert result is False


### PR DESCRIPTION
# Changed reservable before & after rules for online payments

Manually confirmed reservations with online payments are allowed to skip reservable before and after validation. This fixes the issue of changing reservable before/after so that previously made reservations couldn't complete their payments due to these validations.

[Related Trello card](https://trello.com/c/Mrccfa0A)

-----------------------------------------------------------------------------------------------
## Breakdown:

### Reservable before/after rule change
 1. resources/api/reservation.py
     * reservation updates can skip reservable before/after validation with correct state and without any data changes
   
 2. resources/models/utils.py
     * new helper function to check for changes in incoming data vs existing reservation instance