### PR TITLE
Hotfix: Optional fields should also be nullable

### DIFF
--- a/resources/api/base.py
+++ b/resources/api/base.py
@@ -101,6 +101,12 @@ class TranslatedModelSerializer(serializers.ModelSerializer):
         fields = [(key, data[key]) for key in data if key in self.translated_fields]
         for field, value in fields:
             for lang in [x[0] for x in settings.LANGUAGES]:
+                if value is None and self.fields[field].allow_null:
+                    data.update({
+                        '%s_%s' % (field, lang): None
+                    })
+                    continue
+
                 if (not lang in value or not value[lang]) and '%s_%s' % (field, lang) in self.Meta.required_translations:
                     raise ValidationError({
                         field: [
@@ -119,10 +125,10 @@ class TranslatedModelSerializer(serializers.ModelSerializer):
         return data
 
     def validate(self, attrs):
-      attrs = super().validate(attrs)
-      if getattr(self.Meta, 'required_translations', None):
-        self.validate_translation(attrs)
-      return attrs
+        attrs = super().validate(attrs)
+        if getattr(self.Meta, 'required_translations', None):
+            self.validate_translation(attrs)
+        return attrs
 
 
 class NullableTimeField(serializers.TimeField):

--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -1583,11 +1583,13 @@ class ResourceCreateSerializer(TranslatedModelSerializer):
     description = serializers.DictField(required=True)
     responsible_contact_info = serializers.DictField(
         required=False,
-        help_text=get_translated_field_help_text('responsible_contact_info')
+        help_text=get_translated_field_help_text('responsible_contact_info'),
+        allow_null=True
     )
     specific_terms = serializers.DictField(
         required=False,
-        help_text=get_translated_field_help_text('specific_terms')
+        help_text=get_translated_field_help_text('specific_terms'),
+        allow_null=True
     )
     need_manual_confirmation = serializers.BooleanField(required=True)
     authentication = serializers.ChoiceField(choices=Resource.AUTHENTICATION_TYPES, required=True)
@@ -1597,9 +1599,9 @@ class ResourceCreateSerializer(TranslatedModelSerializer):
     slot_size = serializers.DurationField(required=True)
     reservation_info = serializers.DictField(required=True)
 
-    reservation_confirmed_notification_extra = serializers.DictField(required=False)
-    reservation_requested_notification_extra = serializers.DictField(required=False)
-    reservation_additional_information = serializers.DictField(required=False)
+    reservation_confirmed_notification_extra = serializers.DictField(required=False, allow_null=True)
+    reservation_requested_notification_extra = serializers.DictField(required=False, allow_null=True)
+    reservation_additional_information = serializers.DictField(required=False, allow_null=True)
 
     resource_staff_emails = ResourceStaffEmailsField(required=False, allow_empty=True)
 


### PR DESCRIPTION
# Hotfix: Optional fields should be nullable

### Fixes oversight with optional fields

[Trello card](https://trello.com/c/xUj8giZB)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Respa API
 1. resources/api/base.py 
     * Fix field handling
   
 2. resources/api/resource.py
     * Set optional fields to allow null

