### PR TITLE
Fixed simple jwt env usage and settings

### DIFF
--- a/resources/tests/test_api.py
+++ b/resources/tests/test_api.py
@@ -26,8 +26,7 @@ class JWTMixin(object):
         token = AccessToken.for_user(user)
         if 'exp' in extra:
             token.set_exp(from_time=extra['exp'])
-        if 'token_type' in extra:
-            token.token_type = extra['token_type']
+
         return 'JWT %s' % str(token)
 
     def authenticated_post(self, url, data, **extra):
@@ -112,15 +111,9 @@ class ReservationApiTestCase(APITestCase, JWTMixin):
         #self.assertContains(response, '"ends":"' + end.isoformat())
 
     def test_jwt_expired(self):
-        exp = datetime.datetime.utcnow() - datetime.timedelta(minutes=15)
+        exp = datetime.datetime.utcnow() - datetime.timedelta(minutes=16)
         response = self.authenticated_post('/v1/reservation/', {}, exp=exp)
         self.assertEqual(response.status_code, 401)
-
-    def test_jwt_invalid_token_type(self):
-        response = self.authenticated_post('/v1/reservation/', {},
-                                           token_type=generate_random_string(6))
-        self.assertEqual(response.status_code, 400)
-
 
 
 @pytest.mark.skip(reason="availability disabled for now")

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -78,7 +78,7 @@ env = environ.Env(
     MACHINE_TO_MACHINE_AUTH_ENABLED=(bool, False),
     JWT_AUTH_HEADER_PREFIX=(str, "JWT"),
     JWT_LEEWAY=(int, 30), # seconds
-    JWT_LIFETIME=(int, 3600), # generated jwt token expires after this many seconds
+    JWT_LIFETIME=(int, 900), # generated jwt token expires after this many seconds
     JWT_PAYLOAD_HANDLER=(str, 'respa.machine_to_machine_auth.utils.jwt_payload_handler'), # generates jwt token payload
     ENABLE_RESOURCE_TOKEN_AUTH=(bool, False),
     DISABLE_SERVER_SIDE_CURSORS=(bool, False),
@@ -425,13 +425,11 @@ OIDC_AUTH = {
 }
 
 SIMPLE_JWT = {
-    'AUTH_HEADER_TYPES': ('JWT', ),
+    'AUTH_HEADER_TYPES': env('JWT_AUTH_HEADER_PREFIX'),
     'LEEWAY': env('JWT_LEEWAY'),
     'AUDIENCE': env('TOKEN_AUTH_ACCEPTED_AUDIENCE'),
     'SIGNING_KEY': env('TOKEN_AUTH_SHARED_SECRET'),
-    'AUTH_HEADER_PREFIX': env('JWT_AUTH_HEADER_PREFIX'),
-    'EXPIRATION_DELTA': datetime.timedelta(seconds=env('JWT_LIFETIME')),
-    'PAYLOAD_HANDLER': env('JWT_PAYLOAD_HANDLER')
+    'ACCESS_TOKEN_LIFETIME': datetime.timedelta(seconds=env('JWT_LIFETIME')),
 }
 
 # toggles auth token api endpoint url


### PR DESCRIPTION
Changes:
- switched jwt expiration setting from `EXPIRATION_DELTA` to `ACCESS_TOKEN_LIFETIME`
- changed env `JWT_LIFETIME` default from 3600 to 900 seconds
- removed jwt `AUTH_HEADER_PREFIX` and updated `AUTH_HEADER_TYPES` to use env `JWT_AUTH_HEADER_PREFIX`
- removed `PAYLOAD_HANDLER` which is not used by this package
