### PR TITLE
Added feedback link to RA navbar

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2827,3 +2827,6 @@ msgstr ""
 
 msgid "Block reservations"
 msgstr ""
+
+msgid "Give feedback"
+msgstr ""

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2208,3 +2208,6 @@ msgstr "Tavalliset varaukset"
 
 msgid "Block reservations"
 msgstr "Blokkivaraukset"
+
+msgid "Give feedback"
+msgstr "Anna palautetta"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -2149,3 +2149,6 @@ msgstr "Normal bokning"
 
 msgid "Block reservations"
 msgstr "Blockerade bokningar"
+
+msgid "Give feedback"
+msgstr "Ge feedback"

--- a/respa_admin/templates/respa_admin/_nav.html
+++ b/respa_admin/templates/respa_admin/_nav.html
@@ -105,6 +105,16 @@
                     </a>
                 </li>
                 {% endif %}
+                <li>
+                    <a
+                        href="https://opaskartta.turku.fi/eFeedback/{{ LANGUAGE_CODE }}/Feedback/30/1039"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                    >
+                        {% trans "Give feedback" %}
+                        <span class="glyphicon glyphicon-new-window icon-right" aria-hidden="true"></span>
+                    </a>
+                </li>
 
                 {% if INSTRUCTIONS_URL %}
                 <li>


### PR DESCRIPTION
Respa Admin site navbar now includes a feedback link next to 'contact us' link.

[Related Trello card](https://trello.com/c/hkJcdtwr)