### PR TITLE
Fixed RA mobile navigation toggle button not working

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2830,3 +2830,6 @@ msgstr ""
 
 msgid "Give feedback"
 msgstr ""
+
+msgid "Navigation"
+msgstr ""

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2211,3 +2211,6 @@ msgstr "Blokkivaraukset"
 
 msgid "Give feedback"
 msgstr "Anna palautetta"
+
+msgid "Navigation"
+msgstr "Navigaatio"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -2152,3 +2152,6 @@ msgstr "Blockerade bokningar"
 
 msgid "Give feedback"
 msgstr "Ge feedback"
+
+msgid "Navigation"
+msgstr "Navigering"

--- a/respa_admin/templates/respa_admin/_nav.html
+++ b/respa_admin/templates/respa_admin/_nav.html
@@ -60,8 +60,15 @@
     <div class="container">
         <!-- Brand and toggle get grouped for better mobile display -->
         <div class="navbar-header">
-            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-                <span class="sr-only">Toggle navigation</span>
+            <button
+                type="button"
+                class="navbar-toggle collapsed"
+                data-bs-toggle="collapse"
+                data-bs-target="#bs-example-navbar-collapse-1"
+                aria-controls="bs-example-navbar-collapse-1"
+                aria-expanded="false"
+                aria-label="{% trans 'Navigation' %}"
+            >
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>


### PR DESCRIPTION
Previously Respa Admin site's mobile header navigation toggle button did nothing when pressed. This change fixes the button's collapse functionality and adds translated aria-label to the toggle button.