### PR TITLE
Add language dropdown to django admin

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2833,3 +2833,6 @@ msgstr ""
 
 msgid "Navigation"
 msgstr ""
+
+msgid "Select language"
+msgstr ""

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2214,3 +2214,6 @@ msgstr "Anna palautetta"
 
 msgid "Navigation"
 msgstr "Navigaatio"
+
+msgid "Select language"
+msgstr "Valitse kieli"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -2155,3 +2155,6 @@ msgstr "Ge feedback"
 
 msgid "Navigation"
 msgstr "Navigering"
+
+msgid "Select language"
+msgstr "Välj språk"

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -284,7 +284,7 @@ TEMPLATES = [
     },
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [''],
+        'DIRS': ['', 'respa/templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -292,7 +292,8 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'helusers.context_processors.settings'
+                'helusers.context_processors.settings',
+                'django.template.context_processors.i18n',
             ],
         },
     },

--- a/respa/templates/admin/base_site.html
+++ b/respa/templates/admin/base_site.html
@@ -1,0 +1,51 @@
+{% extends "admin/base_site.html" %}
+{% load static %}
+{% load i18n grp_tags %}
+{% get_current_language as LANGUAGE_CODE %}
+{% get_available_languages as LANGUAGES %}
+
+{% block extrastyle %}
+<style>
+    #grp-user-tools li.grp-user-options-container a {
+        text-align: center !important;
+    }
+    #grp-user-tools form.grp-form-set-lang button {
+        display: block;
+        width: 50%;
+        background: none;
+        border: none;
+        color: #4fb2d3;
+        margin: 10px;
+        font-weight: bold;
+        &:hover {
+            color: white;
+        }
+    }
+    #grp-user-tools form.grp-form-set-lang {
+        display: flex;
+        justify-content: center;
+    }
+</style>
+{% endblock %}
+
+{% block userlinks %}
+<li class="grp-collapse grp-closed">
+    <a href="#" class="grp-collapse-handler">
+        {% trans 'Select language' %}
+    </a>
+    <ul class="">
+        {% for code, language in LANGUAGES %}
+            <li class="">
+                <form class="grp-form-set-lang" action="{% url 'set_language' %}" method="post">
+                    <input name="next" type="hidden" value="{{ redirect_to }}">
+                    {% csrf_token %}
+                    <button name="language" value="{{ code }}" href="#">
+                        {{ language }}
+                    </button>
+                </form>
+            </li>
+        {% endfor %}
+    </ul>
+</li>
+{{ block.super }}
+{% endblock %}


### PR DESCRIPTION
### Add language dropdown to django admin

Override Django's `base_site.html` and add language dropdown

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Templates
 1. respa/templates/admin/base_site.html 
     * Add language dropdown
   
