### PR TITLE
Add begin and end time validation for scheduled resource publishing

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2875,3 +2875,6 @@ msgstr ""
 
 msgid "Select language"
 msgstr ""
+
+msgid "End time cannot be in the past"
+msgstr ""

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2256,3 +2256,6 @@ msgstr "Navigaatio"
 
 msgid "Select language"
 msgstr "Valitse kieli"
+
+msgid "End time cannot be in the past"
+msgstr "Päättymisaika ei voi olla menneisyydessä"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -2197,3 +2197,6 @@ msgstr "Navigering"
 
 msgid "Select language"
 msgstr "Välj språk"
+
+msgid "End time cannot be in the past"
+msgstr "Sluttiden kan inte vara i det förflutna"

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -1038,9 +1038,23 @@ class ResourcePublishDate(models.Model):
     def clean(self):
         if not self.begin and not self.end:
             raise ValidationError({
-                'begin': _('This field must be set if {field} is empty').format(field=_('Begin time')).capitalize(),
-                'end': _('This field must be set if {field} is empty').format(field=_('End time')).capitalize(),
+                'begin': _('This field must be set if {field} is empty').format(field=_('End time')).capitalize(),
+                'end': _('This field must be set if {field} is empty').format(field=_('Begin time')).capitalize(),
             })
+        elif self.begin and self.end:
+            if self.begin > self.end:
+                raise ValidationError({
+                    'begin': _('Begin time must be before end time')
+                })
+            
+        if self.begin:
+            self.begin = self.begin.replace(microsecond=0, second=0)
+        if self.end:
+            if timezone.now() > self.end:
+                raise ValidationError({
+                    'end': _('End time cannot be in the past')
+                })
+            self.end = self.end.replace(microsecond=0, second=0)
 
 
     def _get_public(self):

--- a/respa_admin/templates/respa_admin/forms/_form_errors.html
+++ b/respa_admin/templates/respa_admin/forms/_form_errors.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load templatetags %}
 
-{% if form.errors or resource_image_formset.errors or period_formset_with_days.errors or resource_options_formset.errors or resource_universal_formset.errors %}
+{% if form.errors or resource_image_formset.errors or period_formset_with_days.errors or resource_options_formset.errors or resource_universal_formset.errors  or publish_date_formset.errors %}
     <div class="alert alert-danger">
         <strong>{% trans "Check the following errors" %}:</strong>
             {% if form.errors|is_truthy %}


### PR DESCRIPTION
### Add begin and end time validation for scheduled resource publishing

[Trello card](https://trello.com/c/2Gajpgrh)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Validation
 1. resources/api/resource.py 
 2. resources/models/resource.py
     * Add validation for begin and end fields
   