### PR TITLE
Fix: Reservation notification priority

### DIFF
--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -752,7 +752,7 @@ class Reservation(ModifiableModel):
             return self.billing_email_address
         elif self.reserver_email_address:
             return self.reserver_email_address
-        elif user:
+        elif user and not user.is_staff:
             return user.email
 
     def send_reservation_mail(self, notification_type,
@@ -795,7 +795,7 @@ class Reservation(ModifiableModel):
 
         if self.reserver_phone_number:
             if self.resource.send_sms_notification and not staff_email: # Don't send sms when notifying staff.
-                send_respa_sms(self.reserver_phone_number,
+                return send_respa_sms(self.reserver_phone_number,
                     rendered_notification['subject'], rendered_notification['short_message'])
 
 

--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -780,23 +780,24 @@ class Reservation(ModifiableModel):
         except NotificationTemplateException as exc:
             return logger.error(exc, exc_info=True, extra={ 'user': user.uuid if user else None })
 
+        if is_reminder:
+            return send_respa_sms(self.reserver_phone_number,
+                rendered_notification['subject'], rendered_notification['short_message'])
 
-        if self.reserver_phone_number:
-            if is_reminder:
-                return send_respa_sms(self.reserver_phone_number,
-                    rendered_notification['subject'], rendered_notification['short_message'])
-
-            if self.resource.send_sms_notification and not staff_email: # Don't send sms when notifying staff.
-                send_respa_sms(self.reserver_phone_number,
-                    rendered_notification['subject'], rendered_notification['short_message'])
 
         # Use staff email if given, else get the provided email address
         email_address = staff_email if staff_email \
             else self.get_email_address(user)
 
         if email_address:
-            send_respa_mail(email_address, rendered_notification['subject'],
+            return send_respa_mail(email_address, rendered_notification['subject'],
                 rendered_notification['body'], rendered_notification['html_body'], attachments)
+
+        if self.reserver_phone_number:
+            if self.resource.send_sms_notification and not staff_email: # Don't send sms when notifying staff.
+                send_respa_sms(self.reserver_phone_number,
+                    rendered_notification['subject'], rendered_notification['short_message'])
+
 
 
     def notify_staff_about_reservation(self, notification):

--- a/resources/models/utils.py
+++ b/resources/models/utils.py
@@ -26,6 +26,11 @@ from modeltranslation.translator import NotRegistered, translator
 import xlsxwriter
 
 
+class RespaNotificationAction:
+    EMAIL = 'EMAIL'
+    SMS = 'SMS'
+    NONE = None
+
 DEFAULT_LANG = settings.LANGUAGES[0][0]
 
 
@@ -108,7 +113,7 @@ def humanize_duration(duration):
 notification_logger = logging.getLogger('respa.notifications')
 
 
-def send_respa_mail(email_address, subject, body, html_body=None, attachments=None):
+def send_respa_mail(email_address, subject, body, html_body=None, attachments=None) -> RespaNotificationAction:
     if not getattr(settings, 'RESPA_MAILS_ENABLED', False):
         notification_logger.info('Respa mail is not enabled.')
     try:
@@ -120,11 +125,12 @@ def send_respa_mail(email_address, subject, body, html_body=None, attachments=No
         if html_body:
             msg.attach_alternative(html_body, 'text/html')
         msg.send()
+        return RespaNotificationAction.EMAIL
     except Exception as exc:
         notification_logger.error('Respa mail error %s', exc)
 
 
-def send_respa_sms(phone_number, subject, short_message):
+def send_respa_sms(phone_number, subject, short_message) -> RespaNotificationAction:
     if not getattr(settings, 'RESPA_SMS_ENABLED', False):
         notification_logger.info('Respa SMS is not enabled.')
     try:
@@ -132,6 +138,7 @@ def send_respa_sms(phone_number, subject, short_message):
                         'noreply@%s' % Site.objects.get_current().domain)
         sms = EmailMultiAlternatives(subject, short_message, from_address, [f'{phone_number}@{settings.GSM_NOTIFICATION_ADDRESS}'])
         sms.send()
+        return RespaNotificationAction.SMS
     except Exception as exc:
         notification_logger.error('Respa SMS error %s', exc)
 

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -20,6 +20,7 @@ from resources.models import (
     Resource, ResourceGroup, ReservationMetadataField,
     ReservationMetadataSet, UnitAuthorization, ReservationReminder
 )
+from resources.models.utils import build_reservations_ical_file, RespaNotificationAction
 from notifications.models import NotificationTemplate, NotificationType
 from notifications.tests.utils import check_received_mail_exists
 from .utils import (
@@ -1801,6 +1802,44 @@ def test_reservation_created_mail(user_api_client, resource_in_unit, list_url, r
         user.email,
         'Normal reservation created body.'
     )
+
+@override_settings(RESPA_MAILS_ENABLED=True, RESPA_SMS_ENABLED=True)
+@pytest.mark.django_db
+@pytest.mark.parametrize('reserver_email_address,reserver_phone_number,expected_return_type', [
+        ('customer@example.org', None, RespaNotificationAction.EMAIL),
+        (None, '+358404040404', RespaNotificationAction.SMS),
+        ('customer@example.org', '+358404040404', RespaNotificationAction.EMAIL),
+        (None, None, RespaNotificationAction.EMAIL)
+])
+def test_send_reservation_mail_return_type(
+    resource_in_unit, reserver_phone_number, reserver_email_address,
+    staff_api_client, list_url, reservation_data, expected_return_type,
+    user, reservation_created_by_official_notification):
+    if reserver_email_address:
+        reservation_data['reserver_email_address'] = reserver_email_address
+    if reserver_phone_number:
+        reservation_data['reserver_phone_number'] = reserver_phone_number
+
+    meta_field = ReservationMetadataField.objects.get(field_name='reserver_email_address')
+    meta_field2 = ReservationMetadataField.objects.get(field_name='reserver_phone_number')
+    metadata_set = ReservationMetadataSet.objects.create(
+        name='updated_metadata',
+    )
+    metadata_set.supported_fields.set([meta_field, meta_field2])
+    resource_in_unit.reservation_metadata_set = metadata_set
+    resource_in_unit.send_sms_notification = True
+    resource_in_unit.save()
+
+
+    response = staff_api_client.post(list_url, data=reservation_data, format='json')
+    assert response.status_code == 201
+    reservation = Reservation.objects.get(pk=response.json()['id'])
+    attachment = 'reservation.ics', build_reservations_ical_file([reservation]), 'text/calendar'
+    kwargs = {'attachments': [attachment]}
+    if not reserver_email_address and not reserver_phone_number:
+        kwargs['user'] = user
+    return_type = reservation.send_reservation_mail(NotificationType.RESERVATION_CREATED_BY_OFFICIAL, **kwargs)
+    assert return_type == expected_return_type
 
 
 @override_settings(RESPA_MAILS_ENABLED=True)

--- a/respa_outlook/models.py
+++ b/respa_outlook/models.py
@@ -130,12 +130,11 @@ class RespaOutlookConfiguration(models.Model):
             )
             reservation.clean()
             reservation.save()
-            ret = send_respa_mail(
+            send_respa_mail(
                 email_address=email,
                 subject="Reservation created",
                 body="Reservation via outlook created"
             )
-            print(ret[0], ret[1])
 
         RespaOutlookReservation(
             name = '%s (%s)' % (reservation.reserver_email_address, self.resource.name),


### PR DESCRIPTION
#### Fix: Reservation notification priority

Change notification priority, don't send SMS notification if email is provided

[Trello](https://trello.com/c/8PDSPJhR)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Notifications
 1. resources/models/reservation.py 
     * Change notification priority
   
