### PR TITLE
Enforce overnight begin & end values

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2907,3 +2907,6 @@ msgstr ""
 
 msgid "Search tags"
 msgstr ""
+
+msgid "Reservation start and end must match the given overnight reservation start and end values"
+msgstr ""

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2292,3 +2292,6 @@ msgstr "Yön yli varauksen päättymisaika ei voi olla aloitusaikaa pidempi"
 
 msgid "Search tags"
 msgstr "Hakutagit"
+
+msgid "Reservation start and end must match the given overnight reservation start and end values"
+msgstr "Varauksen alkamisajan ja päättymisajan on vastattava annettuja yön yli varauksen alkamisajan ja päättymisajan arvoja"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -2233,3 +2233,6 @@ msgstr "Sluttiden för övernattning kan inte vara senare än starttiden"
 
 msgid "Search tags"
 msgstr "Sök taggar"
+
+msgid "Reservation start and end must match the given overnight reservation start and end values"
+msgstr "Reservationsstart och reservationsslut måste överensstämma med de angivna värdena för start och slut på övernattningen"

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -515,7 +515,7 @@ class Resource(ModifiableModel, AutoIdentifiedModel, ValidatedIdentifier):
             raise ValidationError(_("You cannot make a multiday reservation"))
         
         if self.overnight_reservations:
-            if begin.time() != self.overnight_start_time or end.time() != self.overnight_end_time:
+            if not user.is_superuser and not self.is_manager(user) and (begin.time() != self.overnight_start_time or end.time() != self.overnight_end_time):
                 raise ValidationError(_("Reservation start and end must match the given overnight reservation start and end values"))
 
         if not self.can_ignore_opening_hours(user):

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -514,6 +514,9 @@ class Resource(ModifiableModel, AutoIdentifiedModel, ValidatedIdentifier):
         if is_multiday_reservation and not self.overnight_reservations:
             raise ValidationError(_("You cannot make a multiday reservation"))
         
+        if self.overnight_reservations:
+            if begin.time() != self.overnight_start_time or end.time() != self.overnight_end_time:
+                raise ValidationError(_("Reservation start and end must match the given overnight reservation start and end values"))
 
         if not self.can_ignore_opening_hours(user):
             opening_hours = self.get_opening_hours(begin.date(), end.date())

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -3664,18 +3664,6 @@ def test_overnight_reservation_disabled(
     assert response.status_code == 400
 
 @pytest.mark.django_db
-def test_too_long_overnight_reservation_disallowed(
-    resource_with_overnight_reservations,
-    reservation_data, api_client, user,
-    list_url):
-    reservation_data['begin'] = '2115-04-04T08:00:00+02:00'
-    reservation_data['end'] = '2115-04-06T09:00:00+02:00'
-    reservation_data['resource'] = resource_with_overnight_reservations.pk
-    api_client.force_authenticate(user=user)
-    response = api_client.post(list_url, data=reservation_data)
-    assert response.status_code == 400
-
-@pytest.mark.django_db
 def test_invalid_overnight_reservation_hours(
     resource_with_overnight_reservations,
     reservation_data, api_client, user,

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -3663,15 +3663,22 @@ def test_overnight_reservation_disabled(
     response = api_client.post(list_url, data=reservation_data)
     assert response.status_code == 400
 
+
 @pytest.mark.django_db
+@pytest.mark.parametrize('is_staff', (True, False))
 def test_invalid_overnight_reservation_hours(
     resource_with_overnight_reservations,
-    reservation_data, api_client, user,
-    list_url):
+    reservation_data, is_staff,
+    api_client, user, list_url):
+    if is_staff:
+        resource_with_overnight_reservations.unit.create_authorization(user, 'manager')
     reservation_data['begin'] = '2115-04-04T10:00:00+02:00'
     reservation_data['end'] = '2115-04-05T13:00:00+02:00'
     reservation_data['resource'] = resource_with_overnight_reservations.pk
     api_client.force_authenticate(user=user)
     response = api_client.post(list_url, data=reservation_data, HTTP_ACCEPT_LANGUAGE='en')
-    assert response.status_code == 400
-    assert_non_field_errors_contain(response, 'Reservation start and end must match the given overnight reservation start and end values')
+    if is_staff:
+        assert response.status_code == 201
+    else:
+        assert response.status_code == 400
+        assert_non_field_errors_contain(response, 'Reservation start and end must match the given overnight reservation start and end values')

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -3643,7 +3643,7 @@ def test_overnight_reservation(
     reservation_data, api_client, user,
     list_url):
     reservation_data['begin'] = '2115-04-04T08:00:00+02:00'
-    reservation_data['end'] = '2115-04-05T09:00:00+02:00'
+    reservation_data['end'] = '2115-04-05T16:00:00+02:00'
     reservation_data['resource'] = resource_with_overnight_reservations.pk
     api_client.force_authenticate(user=user)
     response = api_client.post(list_url, data=reservation_data)
@@ -3657,7 +3657,7 @@ def test_overnight_reservation_disabled(
     resource_with_overnight_reservations.overnight_reservations = False
     resource_with_overnight_reservations.save()
     reservation_data['begin'] = '2115-04-04T08:00:00+02:00'
-    reservation_data['end'] = '2115-04-05T09:00:00+02:00'
+    reservation_data['end'] = '2115-04-05T16:00:00+02:00'
     reservation_data['resource'] = resource_with_overnight_reservations.pk
     api_client.force_authenticate(user=user)
     response = api_client.post(list_url, data=reservation_data)

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -3674,3 +3674,16 @@ def test_too_long_overnight_reservation_disallowed(
     api_client.force_authenticate(user=user)
     response = api_client.post(list_url, data=reservation_data)
     assert response.status_code == 400
+
+@pytest.mark.django_db
+def test_invalid_overnight_reservation_hours(
+    resource_with_overnight_reservations,
+    reservation_data, api_client, user,
+    list_url):
+    reservation_data['begin'] = '2115-04-04T10:00:00+02:00'
+    reservation_data['end'] = '2115-04-05T13:00:00+02:00'
+    reservation_data['resource'] = resource_with_overnight_reservations.pk
+    api_client.force_authenticate(user=user)
+    response = api_client.post(list_url, data=reservation_data, HTTP_ACCEPT_LANGUAGE='en')
+    assert response.status_code == 400
+    assert_non_field_errors_contain(response, 'Reservation start and end must match the given overnight reservation start and end values')


### PR DESCRIPTION
### Enforce overnight begin & end values

Add validation to reservation begin & end if overnight is enabled to ensure `time()` values match overnight start and end values

[Trello card](https://trello.com/c/ed52lQyd)
